### PR TITLE
Python 2.7 create_connection compatibility fix.

### DIFF
--- a/httpretty/__init__.py
+++ b/httpretty/__init__.py
@@ -255,11 +255,12 @@ def fake_wrap_socket(s, *args, **kw):
     return s
 
 
-def create_fake_connection(address, timeout=socket._GLOBAL_DEFAULT_TIMEOUT):
+def create_fake_connection(address, timeout=socket._GLOBAL_DEFAULT_TIMEOUT, source_address=None):
     s = fakesock.socket(socket.AF_INET, socket.SOCK_STREAM, socket.IPPROTO_TCP)
     if timeout is not socket._GLOBAL_DEFAULT_TIMEOUT:
         s.settimeout(timeout)
-
+    if source_address:
+        s.bind(source_address)
     s.connect(address)
     return s
 


### PR DESCRIPTION
Since Python 2.7 `create_connection` has had an [optional source_address parameter](http://docs.python.org/library/socket.html#socket.create_connection).  Without the patch in this pull request HTTPretty fails with Python 2.7.  Using the example from the README:

``` python
    >>> urllib2.urlopen('http://globo.com').read()
    Traceback (most recent call last):
      File "<stdin>", line 1, in <module>
      File "/usr/lib64/python2.7/urllib2.py", line 126, in urlopen
        return _opener.open(url, data, timeout)
      File "/usr/lib64/python2.7/urllib2.py", line 392, in open
        response = self._open(req, data)
      File "/usr/lib64/python2.7/urllib2.py", line 410, in _open
        '_open', req)
      File "/usr/lib64/python2.7/urllib2.py", line 370, in _call_chain
        result = func(*args)
      File "/usr/lib64/python2.7/urllib2.py", line 1186, in http_open
        return self.do_open(httplib.HTTPConnection, req)
      File "/usr/lib64/python2.7/urllib2.py", line 1155, in do_open
        h.request(req.get_method(), req.get_selector(), req.data, headers)
      File "/usr/lib64/python2.7/httplib.py", line 941, in request
        self._send_request(method, url, body, headers)
      File "/usr/lib64/python2.7/httplib.py", line 975, in _send_request
        self.endheaders(body)
      File "/usr/lib64/python2.7/httplib.py", line 937, in endheaders
        self._send_output(message_body)
      File "/usr/lib64/python2.7/httplib.py", line 797, in _send_output
        self.send(msg)
      File "/usr/lib64/python2.7/httplib.py", line 759, in send
        self.connect()
      File "/usr/lib64/python2.7/httplib.py", line 740, in connect
        self.timeout, self.source_address)
    TypeError: create_fake_connection() takes at most 2 arguments (3 given)
```

I took the exceedingly lazy option of just kicking the parameter along if given, and ignoring it if not.  If you feel it is important to present the same interface as Python in `create_fake_connection` then I guess a larger patch using `inspect` could be made.

Thanks,

James
