### PR TITLE
response.json is now a method, not a property

### DIFF
--- a/README.md
+++ b/README.md
@@ -27,7 +27,7 @@ def test_yipit_api_returning_deals():
 
     response = requests.get('http://api.yipit.com/v1/deals/')
 
-    expect(response.json).to.equal([{"title": "Test Deal"}])
+    expect(response.json()).to.equal([{"title": "Test Deal"}])
 ```
 
 # A more technical description
@@ -110,7 +110,7 @@ def test_some_api():
 
     response = requests.get('http://foo-api.com/gabrielfalcao')
 
-    expect(response.json).to.equal({'success': False})
+    expect(response.json()).to.equal({'success': False})
     expect(response.status_code).to.equal(500)
 ```
 


### PR DESCRIPTION
When the requests library reached version 1.0, it changed response.json to be a method instead of a property. Update the examples accordingly.
