### PR TITLE
fix missing dictionary conversion in URIMatcher.get_next_entry.

### DIFF
--- a/httpretty/__init__.py
+++ b/httpretty/__init__.py
@@ -692,7 +692,7 @@ class URIMatcher(object):
                              % (method, self))
 
         entry = entries_for_method[self.current_entries[method]]
-        if self.current_entries != -1:
+        if self.current_entries[method] != -1:
             self.current_entries[method] += 1
         return entry
 

--- a/tests/functional/test_requests.py
+++ b/tests/functional/test_requests.py
@@ -450,3 +450,35 @@ def test_httpretty_should_allow_multiple_methods_for_the_same_uri():
     for method in methods:
         request_action = getattr(requests, method.lower())
         expect(request_action(url).text).to.equal(method)
+
+
+@httprettified
+def test_httpretty_should_allow_multiple_responses_with_multiple_methods():
+    u"HTTPretty should allow multiple responses when binding multiple methods to the same uri"
+
+    url = 'http://test.com/list'
+
+    #add get responses
+    HTTPretty.register_uri(HTTPretty.GET, url,
+                           responses=[HTTPretty.Response(body='a'),
+                                      HTTPretty.Response(body='b')
+                           ]
+    )
+
+    #add post responses
+    HTTPretty.register_uri(HTTPretty.POST, url,
+                           responses=[HTTPretty.Response(body='c'),
+                                      HTTPretty.Response(body='d')
+                           ]
+    )
+
+    expect(requests.get(url).text).to.equal('a')
+    expect(requests.post(url).text).to.equal('c')
+
+    expect(requests.get(url).text).to.equal('b')
+    expect(requests.get(url).text).to.equal('b')
+    expect(requests.get(url).text).to.equal('b')
+
+    expect(requests.post(url).text).to.equal('d')
+    expect(requests.post(url).text).to.equal('d')
+    expect(requests.post(url).text).to.equal('d')


### PR DESCRIPTION
In yesterday's patch (63030ca2f2630b46acfbb27916f80b93a75b1c68), I missed one conversion from self.current_entries --> self.current_entries[method]. This affected the order of returned results. If two responses were registered, a and b, then the return order was: 

a
b
b
a
b
b
a
...

This patch fixes the order to be as expected. 
a
b
b
b
...
