### PR TITLE
ensure that calls to the 'setblocking' method on fake sockets are delegated to the underlying socket

### DIFF
--- a/httpretty/__init__.py
+++ b/httpretty/__init__.py
@@ -347,6 +347,8 @@ class fakesock(object):
 
         sendto = send = recvfrom_into = recv_into = recvfrom = recv = debug
 
+        def setblocking(self, *args, **kwargs):
+          return self.truesock.setblocking(*args, **kwargs)
 
 def fake_wrap_socket(s, *args, **kw):
     return s

--- a/tests/unit/test_httpretty.py
+++ b/tests/unit/test_httpretty.py
@@ -180,3 +180,10 @@ def test_Entry_class_normalizes_headers():
         u'Cache-Control': u'no-cache',
         u'X-Forward-For': u'proxy'
     })
+
+
+def test_fake_socket_passes_through_setblocking():
+    import socket
+    HTTPretty.enable()
+    s = socket.socket(socket.AF_INET, socket.SOCK_STREAM)
+    expect(s.setblocking).called_with(0).should_not.throw(AttributeError)


### PR DESCRIPTION
Hi there!

Great work on this, I'm working on a Python project at the moment, after years of doing BDD in Ruby, and it's great to see the tool support for BDD in python getting so good.

However, I ran into a slight problem when using HTTPretty to mock some external web service calls in lettuce acceptance tests for a webapp - if I set up my mocked HTTP endpoints, then spin up an instance of my webapp with paste, paste fails as the socket object it has has no setblocking method. Here's a little patch that fixes that by making sure the fake socket objects always proxy calls to this through to the underlying true socket.

Thanks for a really useful tool!

Cheers,

Tim
