### PR TITLE
Remove querystring from full_url() and thus url regex matching (attempt #2)

### DIFF
--- a/httpretty/core.py
+++ b/httpretty/core.py
@@ -527,14 +527,14 @@ class URIInfo(BaseClass):
         )
         return self_tuple == other_tuple
 
-    def full_url(self):
+    def full_url(self, use_querystring=True):
         credentials = ""
         if self.password:
             credentials = "{0}:{1}@".format(
                 self.username, self.password)
 
         query = ""
-        if self.query:
+        if use_querystring and self.query:
             query = "?{0}".format(decode_utf8(self.query))
 
         result = "{scheme}://{credentials}{host}{path}{query}".format(
@@ -580,7 +580,7 @@ class URIMatcher(object):
         if self.info:
             return self.info == info
         else:
-            return self.regex.search(info.full_url())
+            return self.regex.search(info.full_url(use_querystring=False))
 
     def __str__(self):
         wrap = 'URLMatcher({0})'

--- a/tests/functional/test_requests.py
+++ b/tests/functional/test_requests.py
@@ -502,6 +502,24 @@ def test_httpretty_should_allow_registering_regexes():
 
 
 @httprettified
+def test_httpretty_provides_easy_access_to_querystrings_with_regexes():
+    u"HTTPretty should match regexes even if they have a different querystring"
+
+    HTTPretty.register_uri(
+        HTTPretty.GET,
+        re.compile("https://api.yipit.com/v1/(?P<endpoint>\w+)/$"),
+        body="Find the best daily deals"
+    )
+
+    response = requests.get('https://api.yipit.com/v1/deals/?foo=bar&foo=baz&chuck=norris')
+    expect(response.text).to.equal("Find the best daily deals")
+    expect(HTTPretty.last_request.querystring).to.equal({
+        'foo': ['bar', 'baz'],
+        'chuck': ['norris'],
+    })
+
+
+@httprettified
 def test_httpretty_should_allow_multiple_methods_for_the_same_uri():
     u"HTTPretty should allow registering multiple methods for the same uri"
 

--- a/tests/unit/test_httpretty.py
+++ b/tests/unit/test_httpretty.py
@@ -155,6 +155,10 @@ def test_uri_info_full_url():
         "http://johhny:password@google.com/?foo=bar&baz=test"
     )
 
+    expect(uri_info.full_url(use_querystring=False)).to.equal(
+        "http://johhny:password@google.com/"
+    )
+
 
 def test_global_boolean_enabled():
     expect(HTTPretty.is_enabled()).to.be.falsy


### PR DESCRIPTION
For normal (non-regex) matching, the querystring does not need to be specified for a url to match. This patch would extend that logic to regex url matching.

The alternative is to force people using regex matching to add ?.\* to the end of all urls that they want matched regardless of querystring.
