### PR TITLE
Removed the unicode literal on author

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -53,7 +53,7 @@ def test_packages():
 setup(name='httpretty',
     version=version,
     description='HTTP client mock for Python',
-    author=u'Gabriel Falcao',
+    author='Gabriel Falcao',
     author_email='gabriel@nacaolivre.org',
     url='http://github.com/gabrielfalcao/httpretty',
     packages=get_packages(),


### PR DESCRIPTION
As mentioned in #46, the author string is a unicode literal, which breaks 3.2. The string was ASCII so I just removed the 'u'.
