### PR TITLE
Fix the calculation of Content-Length

### DIFF
--- a/httpretty/core.py
+++ b/httpretty/core.py
@@ -356,8 +356,10 @@ class Entry(BaseClass):
             self.callable_body = body
             self.body = None
             self.body_is_callable = True
-
-        self.body = body
+        elif isinstance(body, text_type):
+            self.body = utf8(body)
+        else:
+            self.body = body
 
         self.streaming = streaming
         if not streaming and not self.body_is_callable:

--- a/tests/unit/test_httpretty.py
+++ b/tests/unit/test_httpretty.py
@@ -28,7 +28,7 @@ from __future__ import unicode_literals
 from mock import MagicMock
 from sure import expect
 from httpretty import HTTPretty, HTTPrettyError
-from httpretty.core import URIInfo, BaseClass, Entry
+from httpretty.core import URIInfo, BaseClass, Entry, FakeSockFile
 from httpretty.http import STATUSES
 
 
@@ -186,6 +186,14 @@ def test_Entry_class_normalizes_headers():
         u'Cache-Control': u'no-cache',
         u'X-Forward-For': u'proxy'
     })
+
+
+def test_Entry_class_counts_multibyte_characters_in_bytes():
+    entry = Entry(HTTPretty.GET, 'http://example.com', 'こんにちは')
+    buf = FakeSockFile()
+    entry.fill_filekind(buf)
+    response = buf.getvalue()
+    expect(b'content-length: 15\n').to.be.within(response)
 
 
 def test_fake_socket_passes_through_setblocking():


### PR DESCRIPTION
HTTPretty calculates Content-Length as the length of the body in characters,
when `body` is `unicode` of multibyte character set.
But it should be the length of the body in bytes.
