### PR TITLE
Adding querystring_post to provide a parse post body

### DIFF
--- a/httpretty/core.py
+++ b/httpretty/core.py
@@ -107,6 +107,7 @@ class HTTPrettyRequest(BaseHTTPRequestHandler, BaseClass):
         self.parse_request()
         self.method = self.command
         self.querystring = parse_qs(self.path.split("?", 1)[-1])
+        self.querystring_post = parse_qs(self.body)
 
     def __str__(self):
         return 'HTTPrettyRequest(headers={0}, body="{1}")'.format(


### PR DESCRIPTION
Hi,

I ran into a problem where I wanted a parsed post body (because I was sending the queryparameters as a post versus a get). I thought it would be cool if this was a prepopulated attribute in the request object, just like with the get querystrings.
