### PR TITLE
Fixing an issue with setup.py being run in a different directory than the egg root

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -39,8 +39,9 @@ def get_packages():
     # setuptools can't do the job :(
     packages = []
     for root, dirnames, filenames in os.walk(os.path.join(HTTPRETTY_PATH, 'httpretty')):
+        path = root.replace(HTTPRETTY_PATH, '').strip('/')
         if '__init__.py' in filenames:
-            packages.append(".".join(os.path.split(root)).strip("."))
+            packages.append(".".join(os.path.split(path)).strip("."))
 
     return packages
 


### PR DESCRIPTION
Hi,

I recently ran into a problem running the setup.py for this from a different directory. Here's a fix so you can run it from any directory and still have the desired behavior.
