### PR TITLE
Adding parsed_body parameter to simplify checks

### DIFF
--- a/httpretty/core.py
+++ b/httpretty/core.py
@@ -102,7 +102,7 @@ class HTTPrettyRequest(BaseHTTPRequestHandler, BaseClass):
     def __init__(self, headers, body=''):
         self.body = utf8(body)
         self.raw_headers = utf8(headers)
-        self.rfile = StringIO(b'\r\n\r\n'.join([headers.strip(), body]))
+        self.rfile = StringIO(b'\r\n\r\n'.join([utf8(headers.strip()), self.body]))
         self.wfile = StringIO()
         self.raw_requestline = self.rfile.readline()
         self.error_code = self.error_message = None
@@ -119,13 +119,14 @@ class HTTPrettyRequest(BaseHTTPRequestHandler, BaseClass):
 
     def __parse_body(self, body):
         """ Attempt to parse the post based on the content-type passed. Return the regular body if not """
-        return_value = body
+        return_value = body.decode('utf-8')
         try:
-            if 'content-type' in self.headers.keys():
-                if self.headers['content-type'].lower() == 'application/json':
-                    return_value = json.loads(body)
-                elif self.headers['content-type'].lower() == 'application/x-www-form-urlencoded':
-                    return_value = parse_qs(body)
+            for header in self.headers.keys():
+                if header.lower() == 'content-type':
+                    if self.headers['content-type'].lower() == 'application/json':
+                        return_value = json.loads(return_value)
+                    elif self.headers['content-type'].lower() == 'application/x-www-form-urlencoded':
+                        return_value = parse_qs(return_value)
         finally:
             return return_value
 

--- a/tests/unit/test_httpretty.py
+++ b/tests/unit/test_httpretty.py
@@ -342,7 +342,7 @@ def test_HTTPrettyRequest_json_body():
 def test_HTTPrettyRequest_invalid_json_body():
     """ A content-type of application/json with an invalid json body should return the content unaltered """
     header = TEST_HEADER % {'content_type': 'application/json'}
-    invalid_json = "{'hello', 'world','thisstringdoesntstops}"
+    invalid_json = u"{'hello', 'world','thisstringdoesntstops}"
     request = HTTPrettyRequest(header, invalid_json)
     expect(request.parsed_body).to.equal(invalid_json)
 
@@ -350,7 +350,7 @@ def test_HTTPrettyRequest_invalid_json_body():
 def test_HTTPrettyRequest_queryparam():
     """ A content-type of x-www-form-urlencoded with a valid queryparam body should return parsed content """
     header = TEST_HEADER % {'content_type': 'application/x-www-form-urlencoded'}
-    valid_queryparam = "hello=world&this=isavalidquerystring"
+    valid_queryparam = u"hello=world&this=isavalidquerystring"
     valid_results = {'hello': ['world'], 'this': ['isavalidquerystring']}
     request = HTTPrettyRequest(header, valid_queryparam)
     expect(request.parsed_body).to.equal(valid_results)


### PR DESCRIPTION
Sorry about not replying on #81, somehow it missed my radar.

I added some tests, and decided to add a bit of extra functionality as well that I think will serve people better in the future.

This pull request adds an additional parameter parsed_body to HTTPrettyRequest:

parsed_body attempts to parse the body if it matches a compatible content type
- content is returned unaltered if it's not a compatible type
- content parses json if content-type type is application/json
- content parse querystring params if content-type is application/x-www-form-urlencoded
- if the value cannot be parsed for any reason (e.g. invalid json), it is unaltered

I was considering adding xml parsing, but I think xml.elementree/minidom as something to work with is a bit more complicated and less intuitive than the dictionary/lists representation of json and querystrings, so I figure that parsing is up to a user's discretion.
