### PR TITLE
Don't duplicate http ports number

### DIFF
--- a/httpretty/core.py
+++ b/httpretty/core.py
@@ -94,7 +94,7 @@ except ImportError:
     ssl = None
 
 
-POTENTIAL_HTTP_PORTS = [80, 443]
+POTENTIAL_HTTP_PORTS = set([80, 443])
 
 
 class HTTPrettyRequest(BaseHTTPRequestHandler, BaseClass):
@@ -263,7 +263,7 @@ class fakesock(object):
 
             # path might come with
             s = urlsplit(path)
-            POTENTIAL_HTTP_PORTS.append(int(s.port or 80))
+            POTENTIAL_HTTP_PORTS.add(int(s.port or 80))
             headers, body = map(utf8, data.split(b'\r\n\r\n', 1))
 
             request = httpretty.historify_request(headers, body)
@@ -585,7 +585,7 @@ class URIInfo(BaseClass):
     @classmethod
     def from_uri(cls, uri, entry):
         result = urlsplit(uri)
-        POTENTIAL_HTTP_PORTS.append(int(result.port or 80))
+        POTENTIAL_HTTP_PORTS.add(int(result.port or 80))
         return cls(result.username,
                    result.password,
                    result.hostname,

--- a/tests/functional/test_bypass.py
+++ b/tests/functional/test_bypass.py
@@ -35,6 +35,7 @@ from .testserver import TornadoServer, TCPServer, TCPClient
 from sure import expect, that_with_context
 
 import httpretty
+from httpretty import core
 
 
 def start_http_server(context):
@@ -92,7 +93,7 @@ def test_httpretty_bypasses_when_disabled(context):
     fd.close()
 
     expect(got3).to.equal(b'glub glub')
-
+    core.POTENTIAL_HTTP_PORTS.remove(9999)
 
 @httpretty.activate
 @that_with_context(start_http_server, stop_http_server)
@@ -114,6 +115,7 @@ def test_httpretty_bypasses_a_unregistered_request(context):
     fd.close()
 
     expect(got2).to.equal(b'<- HELLO WORLD ->')
+    core.POTENTIAL_HTTP_PORTS.remove(9999)
 
 
 @httpretty.activate

--- a/tests/unit/test_httpretty.py
+++ b/tests/unit/test_httpretty.py
@@ -60,11 +60,9 @@ def test_httpretty_should_raise_on_socket_send_when_uri_registered():
     import socket
     HTTPretty.enable()
 
-    defaults = core.POTENTIAL_HTTP_PORTS[:]
-    core.POTENTIAL_HTTP_PORTS = [80, 443]
     HTTPretty.register_uri(HTTPretty.GET,
                            'http://127.0.0.1:5000')
-    expect(core.POTENTIAL_HTTP_PORTS).to.be.equal([80, 443, 5000])
+    expect(core.POTENTIAL_HTTP_PORTS).to.be.equal(set([80, 443, 5000]))
 
     sock = socket.socket(socket.AF_INET, socket.SOCK_STREAM)
     sock.connect(('127.0.0.1', 5000))
@@ -72,7 +70,7 @@ def test_httpretty_should_raise_on_socket_send_when_uri_registered():
     sock.close()
 
     # restore the previous value
-    core.POTENTIAL_HTTP_PORTS = defaults
+    core.POTENTIAL_HTTP_PORTS.remove(5000)
     HTTPretty.reset()
     HTTPretty.disable()
 


### PR DESCRIPTION
Use a set instead of a list to store ports in the POTENTIAL_HTTP_PORTS.
Restore it to its initial value every tests that modify it.
