### PR TITLE
Expose httpretty.reset() to public API

### DIFF
--- a/README.md
+++ b/README.md
@@ -54,6 +54,7 @@ def test_one():
     assert response.text == "Find the best daily deals"
 
     httpretty.disable()  # disable afterwards, so that you will have no problems in code that uses that socket module
+    httpretty.reset()    # reset HTTPretty state (clean up registered urls and request history)
 ```
 
 ## testing query strings

--- a/httpretty/__init__.py
+++ b/httpretty/__init__.py
@@ -38,7 +38,7 @@ activate = httprettified
 
 SELF = sys.modules[__name__]
 
-for attr in [name.decode() for name in httpretty.METHODS] + ['register_uri', 'enable', 'disable', 'is_enabled', 'Response']:
+for attr in [name.decode() for name in httpretty.METHODS] + ['register_uri', 'enable', 'disable', 'is_enabled', 'reset', 'Response']:
     setattr(SELF, attr, getattr(httpretty, attr))
 
 def last_request():


### PR DESCRIPTION
`httpretty.activate()` does `reset()`, but this function isn't available in the public API exposed by httpretty, and thus there is no way to reset the library state with lower-level `enable()` and `disable()` functions. The patch fixes this little annoyance.  
