### PR TITLE
Use common string case for URIInfo hostname comparison.

### DIFF
--- a/httpretty/core.py
+++ b/httpretty/core.py
@@ -553,12 +553,12 @@ class URIInfo(BaseClass):
     def __eq__(self, other):
         self_tuple = (
             self.port,
-            decode_utf8(self.hostname),
+            decode_utf8(self.hostname.lower()),
             url_fix(decode_utf8(self.path)),
         )
         other_tuple = (
             other.port,
-            decode_utf8(other.hostname),
+            decode_utf8(other.hostname.lower()),
             url_fix(decode_utf8(other.path)),
         )
         return self_tuple == other_tuple

--- a/tests/unit/test_httpretty.py
+++ b/tests/unit/test_httpretty.py
@@ -184,7 +184,6 @@ def test_status_codes():
         599: "Network connect timeout error",
     })
 
-
 def test_uri_info_full_url():
     uri_info = URIInfo(
         username='johhny',
@@ -205,6 +204,31 @@ def test_uri_info_full_url():
         "http://johhny:password@google.com/"
     )
 
+def test_uri_info_eq_ignores_case():
+    """Test that URIInfo.__eq__ method ignores case for
+    hostname matching.
+    """
+    uri_info_uppercase = URIInfo(
+        username='johhny',
+        password='password',
+        hostname=b'GOOGLE.COM',
+        port=80,
+        path=b'/',
+        query=b'foo=bar&baz=test',
+        fragment='',
+        scheme='',
+    )
+    uri_info_lowercase = URIInfo(
+        username='johhny',
+        password='password',
+        hostname=b'google.com',
+        port=80,
+        path=b'/',
+        query=b'foo=bar&baz=test',
+        fragment='',
+        scheme='',
+    )
+    expect(uri_info_uppercase).to.equal(uri_info_lowercase)
 
 def test_global_boolean_enabled():
     expect(HTTPretty.is_enabled()).to.be.falsy


### PR DESCRIPTION
If a hostname in mixed case is provided as the `uri` parameter to `register_uri()`, the request will not be patched.
The issue is `urlparse.urlsplit` [1](http://docs.python.org/2/library/urlparse.html#urlparse.urlsplit), which is used to construct an URIInfo instance (`URIInfo.from_uri()`); `urlsplit` returns the hostname part in lowercase, which causes the patched and current-request URIInfos to fail matching in `fakesock.socket.sendall()`. 
