### PR TITLE
Reenable py33 testing via tox.

### DIFF
--- a/tox.ini
+++ b/tox.ini
@@ -1,5 +1,5 @@
 [tox]
-envlist = py26, py27
+envlist = py26, py27, py33
 
 [testenv]
 deps = -r{toxinidir}/requirements.pip


### PR DESCRIPTION
Several months ago, the py33 tests were removed. I just ran them and they passed fine, so whatever issue you may have been having seems to be over.
