### PR TITLE
Fix fake_gethostbyname for requests 2.0

### DIFF
--- a/httpretty/core.py
+++ b/httpretty/core.py
@@ -349,7 +349,7 @@ def create_fake_connection(address, timeout=socket._GLOBAL_DEFAULT_TIMEOUT, sour
 
 
 def fake_gethostbyname(host):
-    return host
+    return '127.0.0.1'
 
 
 def fake_gethostname():


### PR DESCRIPTION
With the newly released requests 2.0, I get a bunch of errors like:

  https://gist.github.com/mgood/6693271

The error originates in `urllib.proxy_bypass` which calls `socket.gethostbyname` to determine whether to use a proxy for an IP address.  Since the `fake_gethostbyname` returns the unaltered hostname instead of an IP, the code that tries to parse the result as an IP address throws an error.

I don't know if there's some other side-effect of the current behavior here, but returning `127.0.0.1` (or any valid IP) instead fixed the tests.

I've run the HTTPretty tests with Tox, bumping the version number in `requirements.pip` to `requests==2.0.0`.  I'm not sure how you want to handle that, since it looks like `requirements.pip` is used for the `tests_require` as well.
