### PR TITLE
Fix OS-specific path handling in setup.py

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -39,7 +39,7 @@ def get_packages():
     # setuptools can't do the job :(
     packages = []
     for root, dirnames, filenames in os.walk(os.path.join(HTTPRETTY_PATH, 'httpretty')):
-        path = root.replace(HTTPRETTY_PATH, '').strip('/')
+        path = root.replace(HTTPRETTY_PATH, '').strip(os.sep)
         if '__init__.py' in filenames:
             packages.append(".".join(os.path.split(path)).strip("."))
 


### PR DESCRIPTION
Attempting to install HTTPretty on Windows (using either `pip` or `easy_install` or `python setup.py install`) fails with the following error:

```
WARNING: '\\.httpretty' not a valid package name; please use only.-separated package names in setup.py

error: package directory '\httpretty' does not exist
```

This patch fixes an OS-specific remnant of the `get_packages` magic in `setup.py` that's causing the error.  (Although really I'd recommend getting rid of it entirely since it's completely unnecessary for this project.)
