### PR TITLE
Don't encode into a binary prior to calling unquote().

### DIFF
--- a/httpretty/core.py
+++ b/httpretty/core.py
@@ -182,7 +182,7 @@ class HTTPrettyRequest(BaseHTTPRequestHandler, BaseClass):
         )
 
     def parse_querystring(self, qs):
-        expanded = decode_utf8(unquote(utf8(qs)))
+        expanded = decode_utf8(unquote(qs))
 
         parsed = parse_qs(expanded)
         result = {}


### PR DESCRIPTION
We are using HTTPretty for unit tests.  When we upgraded to requests 2.0.0 we also upgraded to httpretty 0.7.0 and then all of our unit tests began to break on Python 3.3 with the error:

```
TypeError: Type str doesn't support the buffer API
```

This patch fixes the problem for us and doesn't seem to introduce any regressions on 2.7.x or 2.6.x.  It doesn't look like you are running unit tests on Python 3.3 on TravisCI right now.  Not sure if you need a specific test for this or if the existing tests already detect this issue.  I would think they do.
