### PR TITLE
core: fix for working with python 3.3

### DIFF
--- a/httpretty/compat.py
+++ b/httpretty/compat.py
@@ -59,9 +59,19 @@ class BaseClass(object):
 
 try:  # pragma: no cover
     from urllib.parse import urlsplit, urlunsplit, parse_qs, quote, quote_plus, unquote
+    unquote_utf8 = unquote
 except ImportError:  # pragma: no cover
     from urlparse import urlsplit, urlunsplit, parse_qs, unquote
     from urllib import quote, quote_plus
+    def unquote_utf8(qs):
+        if isinstance(qs, text_type):
+            qs = qs.encode('utf-8')
+        s = unquote(qs)
+        if isinstance(s, byte_type):
+            return s.decode("utf-8")
+        else:
+            return s
+
 
 try:  # pragma: no cover
     from http.server import BaseHTTPRequestHandler

--- a/httpretty/core.py
+++ b/httpretty/core.py
@@ -50,6 +50,7 @@ from .compat import (
     urlsplit,
     parse_qs,
     unquote,
+    unquote_utf8,
     ClassTypes,
     basestring
 )
@@ -182,12 +183,11 @@ class HTTPrettyRequest(BaseHTTPRequestHandler, BaseClass):
         )
 
     def parse_querystring(self, qs):
-        expanded = decode_utf8(unquote(utf8(qs)))
-
+        expanded = unquote_utf8(qs)
         parsed = parse_qs(expanded)
         result = {}
-        for k, v in parsed.iteritems():
-            result[k] = map(decode_utf8, v)
+        for k in parsed:
+            result[k] = map(decode_utf8, parsed[k])
 
         return result
 


### PR DESCRIPTION
The unfixed parse_querystring() raises the following exception
in Python 3.3:

  TypeError: Type str doesn't support the buffer API

Also removed iteritems() as it is deprecated and no longer
supported in Python 3.x

---

The same (or just very similar?) problem is mentioned in https://github.com/gabrielfalcao/HTTPretty/pull/27/files

The original exception:

```
        try:
            self.sock.sendall(data)
        except TypeError:
            if isinstance(data, collections.Iterable):
                for d in data:
>                   self.sock.sendall(d)

/usr/lib64/python3.3/http/client.py:875:
_ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _

self = <httpretty.core.fakesock.socket object at 0x7fe1197e6a90>, data = 71, args = (), kw = {}

    def sendall(self, data, *args, **kw):
        self._sent_data.append(data)

        try:
>           requestline, _ = data.split(b'\r\n', 1)
E           AttributeError: 'int' object has no attribute 'split'

../../env/test/lib/python3.3/site-packages/httpretty-0.7.0-py3.3.egg/httpretty/core.py:346: AttributeError
```
