### PR TITLE
Fix test dependant on ordering

### DIFF
--- a/tests/unit/test_httpretty.py
+++ b/tests/unit/test_httpretty.py
@@ -67,6 +67,7 @@ def test_httpretty_should_raise_on_socket_send_when_uri_registered():
     import socket
     HTTPretty.enable()
 
+    core.POTENTIAL_HTTP_PORTS = set([80, 443])
     HTTPretty.register_uri(HTTPretty.GET,
                            'http://127.0.0.1:5000')
     expect(core.POTENTIAL_HTTP_PORTS).to.be.equal(set([80, 443, 5000]))


### PR DESCRIPTION
If you run the full test suite then the functional tests typically
execute before the unit tests. Because POTENTIAL_HTTP_PORTS is never
reset then there will be an entry for port 8888 in the list which means
the test checking for ONLY the expected ports will fail.
