### PR TITLE
Replaced dynamic module attributes with actual references

### DIFF
--- a/httpretty/__init__.py
+++ b/httpretty/__init__.py
@@ -27,8 +27,6 @@ from __future__ import unicode_literals
 
 __version__ = version = '0.7.0'
 
-import sys
-
 from .core import httpretty, httprettified
 from .errors import HTTPrettyError
 from .core import URIInfo
@@ -36,10 +34,21 @@ from .core import URIInfo
 HTTPretty = httpretty
 activate = httprettified
 
-SELF = sys.modules[__name__]
+enable = httpretty.enable
+register_uri = httpretty.register_uri
+disable = httpretty.disable
+is_enabled = httpretty.is_enabled
+reset = httpretty.reset
+Response = httpretty.Response
 
-for attr in [name.decode() for name in httpretty.METHODS] + ['register_uri', 'enable', 'disable', 'is_enabled', 'reset', 'Response']:
-    setattr(SELF, attr, getattr(httpretty, attr))
+GET = httpretty.GET
+PUT = httpretty.PUT
+POST = httpretty.POST
+DELETE = httpretty.DELETE
+HEAD = httpretty.HEAD
+PATCH = httpretty.PATCH
+OPTIONS = httpretty.OPTIONS
+CONNECT = httpretty.CONNECT
 
 
 def last_request():


### PR DESCRIPTION
My IDE would complain about unresolved references when working with the httpretty package.
To fix this I replaced the dynamic attributes with references to the httpretty classmethods and attributes.
I don't know what the reason was to create those attributes dynamically during runtime in the first place, though.

Running tox passes all tests for py26 and py27 (py33 tests seem to be broken for other reasons).
