### PR TITLE
feat: tox support

### DIFF
--- a/tox.ini
+++ b/tox.ini
@@ -1,0 +1,13 @@
+[tox]
+envlist = py26, py27
+
+[testenv]
+deps = -r{toxinidir}/requirements.txt
+commands = nosetests -s --verbosity=2 --with-coverage --cover-erase --cover-inclusive tests/unit --cover-package=httpretty
+
+[testenv:functional]
+commands = nosetests -s --verbosity=2 --with-coverage --cover-erase --cover-inclusive tests/functional --cover-package=httpretty
+
+[testenv:pep8]
+deps = flake8
+commands = flake8 httpretty tests


### PR DESCRIPTION
tox makes it easy to verify whether tests pass across a variety of
different python versions.

This patch adds that support.
