### PR TITLE
feat: leaner requirements, improved tox/travis support

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -2,12 +2,20 @@ language: python
 python:
   - "2.6"
   - "2.7"
+  - "3.3"
+  - "pypy"
+
+matrix:
+  allow_failures:
+    - python: "3.3"
+    - python: "pypy"
+
 env:
   - TEST_TYPE=unit
   - TEST_TYPE=functional
 
 install:
-  - pip install -r requirements.txt
+  - pip install -r requirements.txt -r test-requirements.txt
 
 script:
   - make $TEST_TYPE

--- a/MANIFEST.in
+++ b/MANIFEST.in
@@ -1,4 +1,5 @@
 include requirements.txt
+include test-requirements.txt
 include dev-requirements.txt
 recursive-include tests *.py
 include tests/functional/fixtures/playback-*.json

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,9 +1,1 @@
-coverage
-httplib2
-mock
-nose
-requests
-tornado
-tox
-sure
 urllib3

--- a/setup.py
+++ b/setup.py
@@ -35,13 +35,13 @@ HTTPretty.disable()
 HTTPRETTY_PATH = os.path.abspath(os.path.join(__file__, os.pardir))
 
 
-def test_packages():
-    test_reqs = os.path.join(HTTPRETTY_PATH, 'requirements.txt')
-    tests_require = [
-            line.strip() for line in open(test_reqs).readlines()
-            if not line.startswith("#")
-        ]
-    return tests_require
+def parse_requirements(reqs_path):
+    target_path = os.path.join(HTTPRETTY_PATH, reqs_path)
+    return [
+        line.strip() for line in open(target_path).readlines()
+        if not line.startswith("#")
+    ]
+
 
 setup(name='httpretty',
     version=version,
@@ -51,8 +51,8 @@ setup(name='httpretty',
     url='http://github.com/gabrielfalcao/httpretty',
     zip_safe=False,
     packages=['httpretty'],
-    tests_require=test_packages(),
-    install_requires=['urllib3'],
+    tests_require=parse_requirements('test-requirements.txt'),
+    install_requires=parse_requirements('requirements.txt'),
     license='MIT',
     test_suite='nose.collector',
     classifiers=["Intended Audience :: Developers",

--- a/test-requirements.txt
+++ b/test-requirements.txt
@@ -1,0 +1,12 @@
+# test runner
+coverage
+nose
+
+# testing utilities
+mock
+sure
+
+# external frameworks tested against
+httplib2
+requests
+tornado

--- a/tox.ini
+++ b/tox.ini
@@ -2,7 +2,8 @@
 envlist = py26, py27
 
 [testenv]
-deps = -r{toxinidir}/requirements.txt
+deps = -r{toxinidir}/test-requirements.txt
+       -r{toxinidir}/requirements.txt
 commands = nosetests -s tests/unit
 
 [testenv:functional]


### PR DESCRIPTION
This patch builds off of #128 and #129. The log speaks:

```
    This patch reorganizes the requirements to install only what's
    necessary for using httpretty. This greatly reduces installation time
    when being pulled in as a dependency for another project. The only
    library required to use httpretty is urllib3.

    The remaining requirements were either pruned or relocated to
    test-requirements.txt. Those that were pruned were either not needed
    or used for non-testing/non-core purposes. Those that were relocated
    were actively used in either unit or functional tests.

    The tox file and the travis yaml have been updated to reflect the
    changes in the requirements files.

    Finally, travis.yaml has leveled up. It now supports running the test
    suite using pypy and python 3.3, with the added benefit that a build
    will still be marked as successful even if py3.3 and pypy fail.
```
