### PR TITLE
Remove bytes in calls to str.split()

### DIFF
--- a/httpretty/core.py
+++ b/httpretty/core.py
@@ -343,7 +343,7 @@ class fakesock(object):
             self._sent_data.append(data)
 
             try:
-                requestline, _ = data.split(b'\r\n', 1)
+                requestline, _ = data.split('\r\n', 1)
                 method, path, version = parse_requestline(requestline)
                 is_parsing_headers = True
             except ValueError:
@@ -372,7 +372,7 @@ class fakesock(object):
             # path might come with
             s = urlsplit(path)
             POTENTIAL_HTTP_PORTS.add(int(s.port or 80))
-            headers, body = map(utf8, data.split(b'\r\n\r\n', 1))
+            headers, body = map(utf8, data.split('\r\n\r\n', 1))
 
             request = httpretty.historify_request(headers, body)
 


### PR DESCRIPTION
It is useless to write foo.split(b'bar') rather than foo.split(bar). In Python
2, this is exactly the same thing:

```
>>> 'fooXbar'.split('X')
['foo', 'bar']
>>> 'fooXbar'.split(b'X')
['foo', 'bar']
```

In Python 3, using bytes in split() is an error:

```
>>> 'fooXbar'.split('X')
['foo', 'bar']
>>> 'fooXbar'.split(b'X')
Traceback (most recent call last):
  File "<stdin>", line 1, in <module>
TypeError: Can't convert 'bytes' object to str implicitly
```
