### PR TITLE
Reset POTENTIAL_HTTP_PORTS with reset

### DIFF
--- a/httpretty/core.py
+++ b/httpretty/core.py
@@ -843,6 +843,8 @@ class httpretty(HttpBaseClass):
 
     @classmethod
     def reset(cls):
+        global POTENTIAL_HTTP_PORTS
+        POTENTIAL_HTTP_PORTS = set([80, 443])
         cls._entries.clear()
         cls.latest_requests = []
         cls.last_request = HTTPrettyRequestEmpty()


### PR DESCRIPTION
HTTPretty.reset removes all the HTTP mocks that are put in places. There
is therefore no reason to keep around potential http ports that are not
in the current list of mocks.

Therefore we should reset that set as well when we reset the mocks.
