### PR TITLE
Expose latest_requests as public

### DIFF
--- a/httpretty/__init__.py
+++ b/httpretty/__init__.py
@@ -54,3 +54,8 @@ CONNECT = httpretty.CONNECT
 def last_request():
     """returns the last request"""
     return httpretty.last_request
+
+
+def latest_requests():
+    """returns all requests"""
+    return httpretty.latest_requests

--- a/tests/unit/test_httpretty.py
+++ b/tests/unit/test_httpretty.py
@@ -108,6 +108,13 @@ def test_does_not_have_last_request_by_default():
     expect(HTTPretty.last_request.body).to.be.empty
 
 
+def test_does_not_have_latest_requests_by_default():
+    'HTTPretty.latest_requests should be empty'
+    HTTPretty.reset()
+
+    expect(HTTPretty.latest_requests).to.be.empty
+
+
 def test_status_codes():
     "HTTPretty supports N status codes"
 


### PR DESCRIPTION
HTTPretty already exposes httpretty.last_request() which provides the
most recent request made. It tracks all the requests made but they are
not provided via the public API. Expose this to users.
