### PR TITLE
don't overwrite content-length header with callable body

### DIFF
--- a/httpretty/core.py
+++ b/httpretty/core.py
@@ -560,9 +560,11 @@ class Entry(BaseClass):
         status = headers.get('status', self.status)
         if self.body_is_callable:
             status, headers, self.body = self.callable_body(self.request, self.info.full_url(), headers)
-            headers.update({
-                'content-length': len(self.body)
-            })
+            headers = self.normalize_headers(headers)
+            if 'content-length' not in headers:
+                headers.update({
+                    'content-length': len(self.body)
+                })
 
         string_list = [
             'HTTP/1.1 %d %s' % (status, STATUSES[status]),

--- a/tests/functional/test_requests.py
+++ b/tests/functional/test_requests.py
@@ -501,6 +501,24 @@ def test_callback_setting_headers_and_status_response(now):
     expect(response.status_code).to.equal(418)
 
 @httprettified
+@within(two=microseconds)
+def test_callback_setting_content_length_on_head(now):
+    ("HTTPretty should call a callback function, use it's return tuple as status code, headers and body"
+     " requests and respect the content-length header when responding to HEAD")
+
+    def request_callback(request, uri, headers):
+        headers.update({'content-length': 12345})
+        return [200,headers, ""]
+
+    HTTPretty.register_uri(
+        HTTPretty.HEAD, "https://api.yahoo.com/test",
+        body=request_callback)
+
+    response = requests.head('https://api.yahoo.com/test')
+    expect(response.headers).to.have.key('content-length').being.equal("12345")
+    expect(response.status_code).to.equal(200)
+
+@httprettified
 def test_httpretty_should_allow_registering_regexes_and_give_a_proper_match_to_the_callback():
     "HTTPretty should allow registering regexes with requests and giva a proper match to the callback"
 


### PR DESCRIPTION
As per https://github.com/spulec/moto/issues/116, there is sometimes a need to set the content-length header of the response from the response callback. In `moto` this is because AWS S3 response to HEAD requests should contain a `content-length` header equal to the underlying object's size. The suggested way of setting `content-length` according to HTTPretty docs is to give the forcing_headers argument to HTTPretty.register_uri, but this is not practical if the value needs to vary with each request. This change permits the response callback to set the content-length header itself without it being overwritten by `HTTPretty`.
