### PR TITLE
Fix timeout and bufsize for hack with real_sendall method

### DIFF
--- a/httpretty/core.py
+++ b/httpretty/core.py
@@ -251,7 +251,7 @@ class fakesock(object):
             self.timeout = socket._GLOBAL_DEFAULT_TIMEOUT
             self._sock = self
             self.is_http = False
-            self._bufsize = 16
+            self._bufsize = httpretty.sock_bufsize
 
         def getpeercert(self, *a, **kw):
             now = datetime.now()
@@ -327,7 +327,8 @@ class fakesock(object):
                               # that
                 self.truesock.connect(self._address)
 
-            self.truesock.settimeout(0)
+            # Don`t let zero timeout
+            self.truesock.settimeout(httpretty.sock_timeout)
             self.truesock.sendall(data, *args, **kw)
 
             should_continue = True
@@ -781,6 +782,11 @@ class httpretty(HttpBaseClass):
 
     last_request = HTTPrettyRequestEmpty()
     _is_enabled = False
+
+    # Timeout for real_sendall
+    sock_timeout = 3
+    # *Real* bufsize for real_sendall
+    sock_bufsize = 32 * 1024
 
     @classmethod
     def match_uriinfo(cls, info):

--- a/tests/unit/test_core.py
+++ b/tests/unit/test_core.py
@@ -316,12 +316,12 @@ def test_fakesock_socket_real_sendall(old_socket):
     real_socket.sendall.assert_called_once_with(b"SOMEDATA", b'some extra args...', foo=b'bar')
 
     # And the timeout was set to 0
-    real_socket.settimeout.assert_called_once_with(0)
+    real_socket.settimeout.assert_called_once_with(3)
 
     # And recv was called with the bufsize
     real_socket.recv.assert_has_calls([
-        call(16),
-        call(16),
+        call(32 * 1024),
+        call(32 * 1024),
     ])
 
     # And the buffer should contain the data from the server
@@ -352,12 +352,12 @@ def test_fakesock_socket_real_sendall_continue_eagain(socket, old_socket):
     real_socket.sendall.assert_called_once_with(b"SOMEDATA", b'some extra args...', foo=b'bar')
 
     # And the timeout was set to 0
-    real_socket.settimeout.assert_called_once_with(0)
+    real_socket.settimeout.assert_called_once_with(3)
 
     # And recv was called with the bufsize
     real_socket.recv.assert_has_calls([
-        call(16),
-        call(16),
+        call(32 * 1024),
+        call(32 * 1024),
     ])
 
     # And the buffer should contain the data from the server
@@ -387,10 +387,10 @@ def test_fakesock_socket_real_sendall_socket_error(socket, old_socket):
     real_socket.sendall.assert_called_once_with(b"SOMEDATA", b'some extra args...', foo=b'bar')
 
     # And the timeout was set to 0
-    real_socket.settimeout.assert_called_once_with(0)
+    real_socket.settimeout.assert_called_once_with(3)
 
     # And recv was called with the bufsize
-    real_socket.recv.assert_called_once_with(16)
+    real_socket.recv.assert_called_once_with(32 * 1024)
 
     # And the buffer should contain the data from the server
     socket.fd.getvalue().should.equal(b"")
@@ -424,12 +424,12 @@ def test_fakesock_socket_real_sendall_when_http(POTENTIAL_HTTP_PORTS, old_socket
     real_socket.connect.assert_called_once_with(('foobar.com', 4000))
 
     # And the timeout was set to 0
-    real_socket.settimeout.assert_called_once_with(0)
+    real_socket.settimeout.assert_called_once_with(3)
 
     # And recv was called with the bufsize
     real_socket.recv.assert_has_calls([
-        call(16),
-        call(16),
+        call(32 * 1024),
+        call(32 * 1024),
     ])
 
     # And the buffer should contain the data from the server


### PR DESCRIPTION
Hi, 

I  face a problem. My test hangs when httpretty uses `real_sendall` method as a proxy to real network socket. I hacked `real_sendall` method and found that very small buffer size is used for receiving data from real socket. A receiving speed with buffer of 16 bytes is very-very-very slow. A timeout for real socket is set to zero. So test is stopped for very long time. 

Please, accept my changes, if you find it is correct. They are usefull for me. But I don`t understand why timeout=0 and bufsize=16 were used and I suspect you may have a reasonable reason to do so.

Thanks in advance!
