### PR TITLE
Fixed an error when "Content-Length" is not int like

### DIFF
--- a/httpretty/core.py
+++ b/httpretty/core.py
@@ -510,6 +510,7 @@ class Entry(BaseClass):
             if got is None:
                 continue
 
+            igot = None
             try:
                 igot = int(got)
             except ValueError:
@@ -518,7 +519,7 @@ class Entry(BaseClass):
                     'with "%r" which is not a number' % got,
                 )
 
-            if igot > self.body_length:
+            if igot and igot > self.body_length:
                 raise HTTPrettyError(
                     'HTTPretty got inconsistent parameters. The header ' \
                     'Content-Length you registered expects size "%d" but ' \

--- a/tests/functional/test_urllib2.py
+++ b/tests/functional/test_urllib2.py
@@ -133,6 +133,7 @@ def test_httpretty_should_allow_forcing_headers_urllib2():
                            body="this is supposed to be the response",
                            forcing_headers={
                                'Content-Type': 'application/xml',
+                               'Content-Length': '35a',
                            })
 
     request = urlopen('http://github.com')
@@ -141,6 +142,7 @@ def test_httpretty_should_allow_forcing_headers_urllib2():
 
     expect(headers).to.equal({
         'content-type': 'application/xml',
+        'content-length': '35a',
     })
 
 


### PR DESCRIPTION
When I write some unittest in HTTPretty, need test some special "HTTP Headers" (like Content-Lenght is not int), but is runs error.

like that(I changed some HTTPretty's unittest code):

``` shell
Traceback (most recent call last):
  File "/home/kun/projects/HTTPretty/local/lib/python2.7/site-packages/nose/case.py", line 197, in runTest
    self.test(*self.arg)
  File "/home/kun/projects/HTTPretty/local/lib/python2.7/site-packages/nose/util.py", line 613, in newfunc
    return func(*arg, **kw)
  File "/home/kun/projects/HTTPretty/httpretty/core.py", line 1013, in wrapper
    return test(*args, **kw)
  File "/home/kun/projects/HTTPretty/local/lib/python2.7/site-packages/sure/__init__.py", line 186, in wrap
    func(*args, **kw)
  File "/home/kun/projects/HTTPretty/tests/functional/test_urllib2.py", line 136, in test_httpretty_should_allow_forcing_headers_urllib2
    'Content-Length': '35a',
  File "/home/kun/projects/HTTPretty/httpretty/core.py", line 892, in register_uri
    cls.Response(method=method, uri=uri, **headers),
  File "/home/kun/projects/HTTPretty/httpretty/core.py", line 915, in Response
    return Entry(method, uri, **headers)
  File "/home/kun/projects/HTTPretty/httpretty/core.py", line 502, in __init__
    self.validate()
  File "/home/kun/projects/HTTPretty/httpretty/core.py", line 521, in validate
    if igot > self.body_length:
UnboundLocalError: local variable 'igot' referenced before assignment
```

So, I edit some core.py's code and change the HTTPretty's unittest, for include this damn situation.
