### PR TITLE
Make tests behave nicely when server startup fails

### DIFF
--- a/tests/functional/base.py
+++ b/tests/functional/base.py
@@ -72,9 +72,11 @@ class JSONEchoServer(threading.Thread):
         ])
 
     def run(self):
-        application = self.setup_application()
-        application.listen(self.port)
-        self.lock.release()
+        try:
+            application = self.setup_application()
+            application.listen(self.port)
+        finally:
+            self.lock.release()
         tornado.ioloop.IOLoop.instance().start()
 
 

--- a/tests/functional/testserver.py
+++ b/tests/functional/testserver.py
@@ -61,6 +61,8 @@ def utf8(s):
 
 true_socket = socket.socket
 
+socket.setdefaulttimeout(.5)
+
 PY3 = sys.version_info[0] == 3
 
 if not PY3:


### PR DESCRIPTION
Two issues:
- In JSONEchoServer, lock.release() wasn't called in a finally block, so an exception raised from server startup resulted in deadlock.
- If a server fails to start, its client blocks indefinitely waiting for it to respond. Solution is to set a timeout so it can give up after a while.

An easy way to reproduce the issues being fixed here is to bind port 8888 with anything and then run the tests, so the server will fail to start because its port is already in use.
