### PR TITLE
Add request body + query params to matcher entry

### DIFF
--- a/httpretty/core.py
+++ b/httpretty/core.py
@@ -173,7 +173,7 @@ class HTTPrettyRequest(BaseHTTPRequestHandler, BaseClass):
         self.path = decode_utf8(self.path)
 
         qstring = self.path.split("?", 1)[-1]
-        self.querystring = self.parse_querystring(qstring)
+        self.querystring = HTTPrettyRequest.parse_querystring(qstring)
 
         # And the body will be attempted to be parsed as
         # `application/json` or `application/x-www-form-urlencoded`
@@ -186,7 +186,8 @@ class HTTPrettyRequest(BaseHTTPRequestHandler, BaseClass):
             len(self.body),
         )
 
-    def parse_querystring(self, qs):
+    @classmethod
+    def parse_querystring(cls, qs):
         expanded = unquote_utf8(qs)
         parsed = parse_qs(expanded)
         result = {}
@@ -201,7 +202,8 @@ class HTTPrettyRequest(BaseHTTPRequestHandler, BaseClass):
         PARSING_FUNCTIONS = {
             'application/json': json.loads,
             'text/json': json.loads,
-            'application/x-www-form-urlencoded': self.parse_querystring,
+            'application/x-www-form-urlencoded':
+                HTTPrettyRequest.parse_querystring,
         }
         FALLBACK_FUNCTION = lambda x: x
 

--- a/readme.rst
+++ b/readme.rst
@@ -353,6 +353,62 @@ looking at the querystring. If you want the querystring to be
 considered, you can set ``match_querystring=True`` when calling
 ``register_uri``.
 
+matching query-string parameters
+--------------------------------
+
+.. code:: python
+
+    @httprettified
+    def test_query_param_matching():
+
+        HTTPretty.register_uri(
+            HTTPretty.GET, "https://api.internetstore.com/cart",
+            query_params={'user': 1},
+            body="""{"items": [725, 8191]}""")
+
+        HTTPretty.register_uri(
+            HTTPretty.GET, "https://api.internetstore.com/cart",
+            query_params={},
+            body="""{"errors": ["User is required."]}""")
+
+        requests.get('https://api.internetstore.com/cart?user=1') \
+            .json().should.equal({'items': [725, 8191]})
+
+        requests.get('https://api.internetstore.com/cart?') \
+            .json().should.equal({'errors': ['User is required.']})
+
+matching request bodies
+-----------------------
+
+.. code:: python
+
+    @httprettified
+    def test_body_matching():
+
+        HTTPretty.register_uri(
+            HTTPretty.POST, "https://api.internetstore.com/purchase",
+            request_body=b"""{"items": [3,8]}""",
+            body="""{"confirmation_number": 916492}""",
+            content_type='application/json')
+
+        HTTPretty.register_uri(
+            HTTPretty.POST, "https://api.internetstore.com/purchase",
+            request_body=b"""{"items": [6,7]}""",
+            body="""{"errors": ["Item 6 is unavailable."]}""",
+            content_type='application/json')
+
+        requests.post(
+            'https://api.internetstore.com/purchase',
+            data=b"""{"items": [3,8]}""",
+            headers={'content-type': 'text/json'},
+        ).json().should.equal({'confirmation_number': 916492})
+
+        requests.post(
+            'https://api.internetstore.com/purchase',
+            data=b"""{"items": [6,7]}""",
+            headers={'content-type': 'text/json'},
+        ).json().should.equal({'errors': ['Item 6 is unavailable.']})
+
 expect for a response, and check the request got by the "server" to make sure it was fine.
 ------------------------------------------------------------------------------------------
 


### PR DESCRIPTION
For APIs where parameters are part of the URIs, httpretty works fine:

``` python
HTTPretty.register_uri(HTTPretty.GET,
    'https://example.com/widgets/1/status', body='ok')
HTTPretty.register_uri(HTTPretty.GET,
    'https://example.com/widgets/2/status', body='bad')
```

But when the parameters move to a POST body, the model of matching requests by method and URI alone breaks down - we need to be able to match on the body too:

``` python
HTTPretty.register_uri(HTTPretty.POST,
    'https://example.com/widget-status',
    request_body=b'{"id": 1}', body='ok')
HTTPretty.register_uri(HTTPretty.POST,
    'https://example.com/widget-status',
    request_body=b'{"id": 2}', body='bad')
```

Another problem crops up when we have multiple query string parameters, and their values matter, but their order is arbitrary. This entry, for example,

``` python
HTTPretty.register_uri(HTTPretty.GET,
    'https://example.com/widgets?status=ok&sort=name',
    match_querystring=True, body='[5,81]'))
```

matches

```
      https://example.com/widgets?status=ok&sort=name
```

but not

```
      https://example.com/widgets?sort=name&status=ok
```

We can fix this by adding another match criterion by which we specify the query string as a dict.

``` python
HTTPretty.register_uri(HTTPretty.GET, 'https://example.com/widgets',
    query_params={'status': 'ok', 'sort': 'name'}, body='[5,81]'))
```

The logic of `URIMatcher.get_next_entry` is now generalized as: "Choose the first matching entry that hasn't been used yet. If all matching entries have been used, repeat the last one."
