### PR TITLE
Decorate unittest.TestCase setUp/tearDown methods

### DIFF
--- a/tests/functional/test_decorator.py
+++ b/tests/functional/test_decorator.py
@@ -23,6 +23,34 @@ def test_decor():
 
 
 @httprettified
+class DecoratedNonUnitTest(object):
+
+    def test_fail(self):
+        raise AssertionError('Tests in this class should not '
+                             'be executed by the test runner.')
+
+    def test_decorated(self):
+        HTTPretty.register_uri(
+            HTTPretty.GET, "http://localhost/",
+            body="glub glub")
+
+        fd = urllib2.urlopen('http://localhost/')
+        got1 = fd.read()
+        fd.close()
+
+        expect(got1).to.equal(b'glub glub')
+
+
+class NonUnitTestTest(TestCase):
+    """
+    Checks that the test methods in DecoratedNonUnitTest were decorated.
+    """
+
+    def test_decorated(self):
+        DecoratedNonUnitTest().test_decorated()
+
+
+@httprettified
 class ClassDecorator(TestCase):
 
     def test_decorated(self):
@@ -46,3 +74,42 @@ class ClassDecorator(TestCase):
         fd.close()
 
         expect(got1).to.equal(b'buble buble')
+
+@httprettified
+class ClassDecoratorWithSetUp(TestCase):
+
+    def setUp(self):
+        HTTPretty.register_uri(
+            HTTPretty.GET, "http://localhost/",
+            responses=[
+                HTTPretty.Response("glub glub"),
+                HTTPretty.Response("buble buble"),
+            ])
+
+    def test_decorated(self):
+
+        fd = urllib2.urlopen('http://localhost/')
+        got1 = fd.read()
+        fd.close()
+
+        expect(got1).to.equal(b'glub glub')
+
+        fd = urllib2.urlopen('http://localhost/')
+        got2 = fd.read()
+        fd.close()
+
+        expect(got2).to.equal(b'buble buble')
+
+    def test_decorated2(self):
+
+        fd = urllib2.urlopen('http://localhost/')
+        got1 = fd.read()
+        fd.close()
+
+        expect(got1).to.equal(b'glub glub')
+
+        fd = urllib2.urlopen('http://localhost/')
+        got2 = fd.read()
+        fd.close()
+
+        expect(got2).to.equal(b'buble buble')


### PR DESCRIPTION
When the class being decorated by `httprettified` inherits from unittest.TestCase, enable HTTPretty in `setUp` rather than decorating each test separately. This lets users register their HTTP mock entries in `setUp` if they want.