### PR TITLE
Fix for https://github.com/gabrielfalcao/HTTPretty/issues/188

### DIFF
--- a/httpretty/__init__.py
+++ b/httpretty/__init__.py
@@ -25,7 +25,7 @@
 # OTHER DEALINGS IN THE SOFTWARE.
 from __future__ import unicode_literals
 
-__version__ = version = '0.8.3'
+__version__ = version = '0.8.3.1'
 
 from .core import httpretty, httprettified
 from .errors import HTTPrettyError

--- a/httpretty/core.py
+++ b/httpretty/core.py
@@ -288,7 +288,7 @@ class fakesock(object):
             self.type = type
 
         def connect(self, address):
-            if type(address) != type(tuple()): #a string unix socket file name
+            if isinstance(address, str): #a string unix socket file name
                 (self._address, self._port) = (address, None)
             else:
                 self._address = (self._host, self._port) = address

--- a/httpretty/core.py
+++ b/httpretty/core.py
@@ -288,7 +288,7 @@ class fakesock(object):
             self.type = type
 
         def connect(self, address):
-            if isinstance(address, str): #a string unix socket file name
+            if type(address) != type(tuple()): #a string unix socket file name
                 (self._address, self._port) = (address, None)
             else:
                 self._address = (self._host, self._port) = address

--- a/httpretty/core.py
+++ b/httpretty/core.py
@@ -288,7 +288,10 @@ class fakesock(object):
             self.type = type
 
         def connect(self, address):
-            self._address = (self._host, self._port) = address
+            if len(address)<2:
+                self._address = (address[0], None)
+            else:
+                self._address = (self._host, self._port) = address
             self._closed = False
             self.is_http = self._port in POTENTIAL_HTTP_PORTS | POTENTIAL_HTTPS_PORTS
 

--- a/httpretty/core.py
+++ b/httpretty/core.py
@@ -288,8 +288,8 @@ class fakesock(object):
             self.type = type
 
         def connect(self, address):
-            if len(address)<2:
-                self._address = (address[0], None)
+            if len(address)>2: #a string unix socket file name
+                self._address = (address, None)
             else:
                 self._address = (self._host, self._port) = address
             self._closed = False

--- a/httpretty/core.py
+++ b/httpretty/core.py
@@ -289,7 +289,7 @@ class fakesock(object):
 
         def connect(self, address):
             if len(address)>2: #a string unix socket file name
-                self._address = (address, None)
+                (self._address, self._port) = (address, None)
             else:
                 self._address = (self._host, self._port) = address
             self._closed = False

--- a/httpretty/core.py
+++ b/httpretty/core.py
@@ -288,7 +288,7 @@ class fakesock(object):
             self.type = type
 
         def connect(self, address):
-            if len(address)>2: #a string unix socket file name
+            if type(address) != type(tuple()): #a string unix socket file name
                 (self._address, self._port) = (address, None)
             else:
                 self._address = (self._host, self._port) = address


### PR DESCRIPTION
The following code fixes 
https://github.com/gabrielfalcao/HTTPretty/issues/188
Basically unix socket connect calls get string - the path to file as an address
