### PR TITLE
fixed invalid content-length bug

### DIFF
--- a/httpretty/core.py
+++ b/httpretty/core.py
@@ -514,11 +514,11 @@ class Entry(BaseClass):
 
             try:
                 igot = int(got)
-            except ValueError:
+            except (ValueError, TypeError):
                 warnings.warn(
                     'HTTPretty got to register the Content-Length header ' \
-                    'with "%r" which is not a number' % got,
-                )
+                    'with "%r" which is not a number' % got)
+                return
 
             if igot > self.body_length:
                 raise HTTPrettyError(


### PR DESCRIPTION
SourceCode
-----------------
```
    def test_if_html_data_gt_max_length(self):
        self.register_url_with_forcing_headers(forcing_headers={
            'content-length': '100a',
        }, body='x' * (config.MAX_CONTENT_LENGTH + 1))
```

Error Traceback 
----------------------
```
======================================================================
ERROR: test_if_html_data_gt_max_length (xxx.tests.test_fetch.HttpContentLengthTestCase)
----------------------------------------------------------------------
Traceback (most recent call last):
  File "/usr/local/lib/python2.6/dist-packages/httpretty/core.py", line 804, in wrapper
    return test(*args, **kw)
  File "/var/data/users/chenj/myhome/gitlab404_projects/kscomm_dev/kscomm/spider/tests/test_fetch.py", line 371, in test_if_html_data_gt_max_length
    }, body='x' * (config.MAX_CONTENT_LENGTH + 1))
  File "/var/data/users/chenj/myhome/gitlab404_projects/kscomm_dev/kscomm/spider/tests/test_fetch.py", line 202, in register_url_with_forcing_headers
    forcing_headers=forcing_headers
  File "/usr/local/lib/python2.6/dist-packages/httpretty/core.py", line 684, in register_uri
    cls.Response(method=method, uri=uri, **headers),
  File "/usr/local/lib/python2.6/dist-packages/httpretty/core.py", line 706, in Response
    return Entry(method, uri, **headers)
  File "/usr/local/lib/python2.6/dist-packages/httpretty/core.py", line 380, in __init__
    self.validate()
  File "/usr/local/lib/python2.6/dist-packages/httpretty/core.py", line 399, in validate
    if igot > self.body_length:
UnboundLocalError: local variable 'igot' referenced before assignment
```