### PR TITLE
Fixes a Py3.4 issue where faking SocketType breaks

### DIFF
--- a/httpretty/core.py
+++ b/httpretty/core.py
@@ -73,6 +73,7 @@ from datetime import timedelta
 from errno import EAGAIN
 
 old_socket = socket.socket
+old_SocketType = socket.SocketType
 old_create_connection = socket.create_connection
 old_gethostbyname = socket.gethostbyname
 old_gethostname = socket.gethostname
@@ -934,7 +935,7 @@ class httpretty(HttpBaseClass):
     def disable(cls):
         cls._is_enabled = False
         socket.socket = old_socket
-        socket.SocketType = old_socket
+        socket.SocketType = old_SocketType
         socket._socketobject = old_socket
 
         socket.create_connection = old_create_connection
@@ -944,7 +945,7 @@ class httpretty(HttpBaseClass):
 
         socket.__dict__['socket'] = old_socket
         socket.__dict__['_socketobject'] = old_socket
-        socket.__dict__['SocketType'] = old_socket
+        socket.__dict__['SocketType'] = old_SocketType
 
         socket.__dict__['create_connection'] = old_create_connection
         socket.__dict__['gethostname'] = old_gethostname


### PR DESCRIPTION
The overall problem is that in Python 3.4 SocketType is not the same
object as socket. This assumption from enable/disable caused an infinite
loop when shutting down after our tests ran. If we save off the original
value and restore it we no longer have an issue.