### PR TITLE
Speed up last_requestline lookup of headers

### DIFF
--- a/httpretty/core.py
+++ b/httpretty/core.py
@@ -348,6 +348,7 @@ class fakesock(object):
 
         def sendall(self, data, *args, **kw):
             self._sent_data.append(data)
+            self._header_data.append(data)
 
             try:
                 requestline, _ = data.split(b'\r\n', 1)
@@ -364,7 +365,11 @@ class fakesock(object):
 
             if not is_parsing_headers:
                 if len(self._sent_data) > 1:
-                    headers = utf8(last_requestline(self._sent_data))
+                    try:
+                        _ = parse_requestline(data)
+                    except ValueError:
+                        self._header_data.pop()
+                    headers = utf8(last_requestline(self._header_data))
                     meta = self._entry.request.headers
                     body = utf8(self._sent_data[-1])
                     if meta.get('transfer-encoding', '') == 'chunked':


### PR DESCRIPTION
When using HTTPretty with moto, I found the S3 tests were very slow. After profiling the code, I discovered a large amount of time was spent in last_requestline. This is because every chunk of data uploaded in an S3 multipart upload is added to self._sent_data, causing the list to get very long and with data that is not header data. This change keeps a cached list of just header data entries to improve the speed of this lookup. It is a bit of a hack, so feel free to do something more intelligent, but it did improve my unit test speed by 8x.