### PR TITLE
Bug Fix - Decorator could skip disabling httpretty

### DIFF
--- a/httpretty/core.py
+++ b/httpretty/core.py
@@ -1026,9 +1026,10 @@ def httprettified(test):
             httpretty.reset()
             httpretty.enable()
             try:
-                return test(*args, **kw)
+                returnValue = test(*args, **kw)
             finally:
                 httpretty.disable()
+                return returnValue
         return wrapper
 
     if isinstance(test, ClassTypes):


### PR DESCRIPTION
HTTPretty is only disabled by the decorator if the wrapped function
has an exception as on successful cases the finally block is never
executed