### PR TITLE
Disable sendall/recv magic for non-http(s) sockets

### DIFF
--- a/httpretty/core.py
+++ b/httpretty/core.py
@@ -338,6 +338,8 @@ class fakesock(object):
                               # False because self.connect already did
                               # that
                 self.truesock.connect(self._address)
+            else:
+                return self.truesock.sendall(data, *args, **kw)
 
             self.truesock.settimeout(0)
             self.truesock.sendall(data, *args, **kw)


### PR DESCRIPTION
Fixes #184