### PR TITLE
The worst PR that fixes all the things

### DIFF
--- a/tests/unit/test_core.py
+++ b/tests/unit/test_core.py
@@ -315,13 +315,12 @@ def test_fakesock_socket_real_sendall(old_socket):
     # Then it should have called sendall in the real socket
     real_socket.sendall.assert_called_once_with(b"SOMEDATA", b'some extra args...', foo=b'bar')
 
-    # And the timeout was set to 0
-    real_socket.settimeout.assert_called_once_with(0)
+    # And the socket was set to blocking
+    real_socket.setblocking.assert_called_once_with(1)
 
     # And recv was called with the bufsize
     real_socket.recv.assert_has_calls([
-        call(16),
-        call(16),
+        call(socket._bufsize)
     ])
 
     # And the buffer should contain the data from the server
@@ -351,13 +350,12 @@ def test_fakesock_socket_real_sendall_continue_eagain(socket, old_socket):
     # Then it should have called sendall in the real socket
     real_socket.sendall.assert_called_once_with(b"SOMEDATA", b'some extra args...', foo=b'bar')
 
-    # And the timeout was set to 0
-    real_socket.settimeout.assert_called_once_with(0)
+    # And the socket was set to blocking
+    real_socket.setblocking.assert_called_once_with(1)
 
     # And recv was called with the bufsize
     real_socket.recv.assert_has_calls([
-        call(16),
-        call(16),
+        call(socket._bufsize)
     ])
 
     # And the buffer should contain the data from the server
@@ -386,11 +384,11 @@ def test_fakesock_socket_real_sendall_socket_error(socket, old_socket):
     # Then it should have called sendall in the real socket
     real_socket.sendall.assert_called_once_with(b"SOMEDATA", b'some extra args...', foo=b'bar')
 
-    # And the timeout was set to 0
-    real_socket.settimeout.assert_called_once_with(0)
+    # And the socket was set to blocking
+    real_socket.setblocking.assert_called_once_with(1)
 
     # And recv was called with the bufsize
-    real_socket.recv.assert_called_once_with(16)
+    real_socket.recv.assert_called_once_with(socket._bufsize)
 
     # And the buffer should contain the data from the server
     socket.fd.getvalue().should.equal(b"")
@@ -423,13 +421,12 @@ def test_fakesock_socket_real_sendall_when_http(POTENTIAL_HTTP_PORTS, old_socket
     # Then connect should have been called
     real_socket.connect.assert_called_once_with(('foobar.com', 4000))
 
-    # And the timeout was set to 0
-    real_socket.settimeout.assert_called_once_with(0)
+    # And the socket was set to blocking
+    real_socket.setblocking.assert_called_once_with(1)
 
     # And recv was called with the bufsize
     real_socket.recv.assert_has_calls([
-        call(16),
-        call(16),
+        call(socket._bufsize)
     ])
 
     # And the buffer should contain the data from the server


### PR DESCRIPTION
Notice: I know next to nothing about sockets and this is me monkeying around with a lot of things.

I did find a bug which I know is a bug, setsockopt, also I think that keeping the fd around without anyone truncating it is a bad idea, so I replaced that with a fd that goes away.

I believe this fixes things like #208 #184 #194 #182. Please test with real world external apps on weird ports (I'm using Dynamo on local 8000 which now works fine during mocking active). Thanks!

Changes:

removing bad setsockopt implementation and replacing with a passthrough to the real socket
setting the socket to blocking in the case of 'real' socket
forcing the close command on the fd to close the socket
replacing the fd at the start of each sendall