### PR TITLE
Don't pin requirements

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,4 +1,4 @@
-httplib2==0.9
-requests==2.5.1
-tornado==4.0.2
-urllib3==1.7.1
+httplib2>=0.9
+requests>=2.5.1
+tornado>=4.0.2
+urllib3>=1.7.1


### PR DESCRIPTION
If I depend on a requests library that is newer then 2.5.1 or older then 2.5.1 installing httpretty will mess with my environment.
Please don't pin requirements. It's the responsibility of the developers to do so before deploying to production.