### PR TITLE
Add priority argument to register_uri.

### DIFF
--- a/tests/functional/test_requests.py
+++ b/tests/functional/test_requests.py
@@ -501,6 +501,23 @@ def test_callback_setting_headers_and_status_response(now):
     expect(response.status_code).to.equal(418)
 
 @httprettified
+def test_httpretty_should_respect_matcher_priority():
+    HTTPretty.register_uri(
+        HTTPretty.GET,
+        re.compile(r".*"),
+        body='high priority',
+        priority=5,
+    )
+    HTTPretty.register_uri(
+        HTTPretty.GET,
+        re.compile(r".+"),
+        body='low priority',
+        priority=0,
+    )
+    response = requests.get('http://api.yipit.com/v1/')
+    expect(response.text).to.equal('high priority')
+
+@httprettified
 def test_httpretty_should_allow_registering_regexes_and_give_a_proper_match_to_the_callback():
     "HTTPretty should allow registering regexes with requests and giva a proper match to the callback"
 


### PR DESCRIPTION
Matchers are stored in a dictionary and are checked in an unpredictable
order. This can be a problem when multiple matchers match the same
URI--for example, when using multiple regex matchers. This patch adds an
optional an optional `priority` argument to `register_uri` to resolve this
ambiguity. When matching a URI, matchers are sorted descending by
priority, and the first match is used. This patch is fully backwards-compatible
and will only behave differently from the current version if `priority` is
specified.