### PR TITLE
add httpretty.has_request() and test

### DIFF
--- a/README.md
+++ b/README.md
@@ -382,6 +382,34 @@ def test_yipit_api_integration():
     expect(httpretty.last_request().headers['content-type']).to.equal('text/json')
 ```
 
+## checking whether a request was made or not
+
+```python
+import httpretty
+import requests
+
+def order_pizza(user, home_delivery=True):
+    check_number = make_pizza()
+    if home_delivery:
+        requests.post('http://api.pizzas.com/deliveries/', {'address': user.address, 'check_number': check_number})
+    else:
+        # for pick up.
+        pass
+    return check_number
+    
+@httpretty.activate
+def test_pizza_delivery():
+    httpretty.register_uri(httpretty.POST, 'http://api.pizzas.com/deliveries/', body='OK')
+
+    order_pizza(some_user)
+    expect(httpretty.has_request()).to.be.true
+
+    httpretty.reset()
+    order_pizza(some_user, home_delivery=False)
+    expect(httpretty.has_request()).to.be.false
+
+```
+
 ## checking if is enabled
 
 ```python

--- a/README.rst
+++ b/README.rst
@@ -378,6 +378,34 @@ expect for a response, and check the request got by the "server" to make sure it
         expect(httpretty.last_request().method).to.equal("POST")
         expect(httpretty.last_request().headers['content-type']).to.equal('text/json')
 
+checking whether a request was made or not
+------------------------------------------
+
+.. code:: python
+
+    import httpretty
+    import requests
+
+    def order_pizza(user, home_delivery=True):
+        check_number = make_pizza()
+        if home_delivery:
+            requests.post('http://api.pizzas.com/deliveries/', {'address': user.address, 'check_number': check_number})
+        else:
+            # for pick up.
+            pass
+        return check_number
+
+    @httpretty.activate
+    def test_pizza_delivery():
+        httpretty.register_uri(httpretty.POST, 'http://api.pizzas.com/deliveries/', body='OK')
+
+        order_pizza(some_user)
+        expect(httpretty.has_request()).to.be.true
+
+        httpretty.reset()
+        order_pizza(some_user, home_delivery=False)
+        expect(httpretty.has_request()).to.be.false
+
 checking if is enabled
 ----------------------
 

--- a/docs/docs.md
+++ b/docs/docs.md
@@ -286,6 +286,34 @@ def test_yipit_api_integration():
     expect(httpretty.last_request().headers['content-type']).to.equal('text/json')
 ```
 
+## checking whether a request was made or not
+
+```python
+import httpretty
+import requests
+
+def order_pizza(user, home_delivery=True):
+    check_number = make_pizza()
+    if home_delivery:
+        requests.post('http://api.pizzas.com/deliveries/', {'address': user.address, 'check_number': check_number})
+    else:
+        # for pick up.
+        pass
+    return check_number
+    
+@httpretty.activate
+def test_pizza_delivery():
+    httpretty.register_uri(httpretty.POST, 'http://api.pizzas.com/deliveries/', body='OK')
+
+    order_pizza(some_user)
+    expect(httpretty.has_request()).to.be.true
+
+    httpretty.reset()
+    order_pizza(some_user, home_delivery=False)
+    expect(httpretty.has_request()).to.be.false
+
+```
+
 ## checking if is enabled
 
 ```python

--- a/httpretty/__init__.py
+++ b/httpretty/__init__.py
@@ -27,7 +27,7 @@ from __future__ import unicode_literals
 
 __version__ = version = '0.8.8'
 
-from .core import httpretty, httprettified
+from .core import httpretty, httprettified, EmptyRequestHeaders
 from .errors import HTTPrettyError, UnmockedError
 from .core import URIInfo
 
@@ -54,3 +54,7 @@ CONNECT = httpretty.CONNECT
 def last_request():
     """returns the last request"""
     return httpretty.last_request
+
+def has_request():
+    """returns a boolean indicating whether any request has been made"""
+    return not isinstance(httpretty.last_request.headers, EmptyRequestHeaders)

--- a/tests/unit/test_main.py
+++ b/tests/unit/test_main.py
@@ -3,6 +3,7 @@
 from __future__ import unicode_literals
 from mock import patch
 import httpretty
+from httpretty.core import HTTPrettyRequest
 
 
 @patch('httpretty.httpretty')
@@ -10,3 +11,9 @@ def test_last_request(original):
     ("httpretty.last_request() should return httpretty.core.last_request")
 
     httpretty.last_request().should.equal(original.last_request)
+
+def test_has_request():
+    """httpretty.has_request() correctly detects whether or not a request has been made"""
+    httpretty.has_request().should.be.false
+    with patch('httpretty.httpretty.last_request', return_value=HTTPrettyRequest('')):
+        httpretty.has_request().should.be.true


### PR DESCRIPTION
@gabrielfalcao thanks for providing this useful library.

In many of the tests I write I want there to be a simple, readable API for determining whether or not any request was actually captured.  This PR adds one method to do that.
