### PR TITLE
Thread safe Entry class usage

### DIFF
--- a/httpretty/core.py
+++ b/httpretty/core.py
@@ -801,14 +801,21 @@ class URIMatcher(object):
         if self.current_entries[method] != -1:
             self.current_entries[method] += 1
 
-        # Attach more info to the entry
-        # So the callback can be more clever about what to do
-        # This does also fix the case where the callback
-        # would be handed a compiled regex as uri instead of the
-        # real uri
-        entry.info = info
-        entry.request = request
-        return entry
+        # Create a copy of the original entry to make it thread-safe
+        body = entry.callable_body if entry.body_is_callable else entry.body
+        new_entry = Entry(entry.method, entry.uri, body,
+                          status=entry.status,
+                          streaming=entry.streaming,
+                          adding_headers=entry.adding_headers,
+                          forcing_headers=entry.forcing_headers)
+
+        # Attach more info to the entry so the callback can be more clever about
+        # what to do. This does also fix the case where the callback would be
+        # handed a compiled regex as uri instead of the real uri
+        new_entry.info = info
+        new_entry.request = request
+
+        return new_entry
 
     def __hash__(self):
         return hash(text_type(self))

--- a/tests/functional/test_requests.py
+++ b/tests/functional/test_requests.py
@@ -325,7 +325,7 @@ def test_streaming_responses(now):
 
     #test iterating by line after a second request
     response = requests.post(TWITTER_STREAMING_URL, data={'track': 'requests'},
-                            auth=('username', 'password'), stream=True)
+                             auth=('username', 'password'), stream=True)
 
     line_iter = response.iter_lines()
     with in_time(0.01, 'Iterating by line is taking forever the second time '
@@ -336,7 +336,7 @@ def test_streaming_responses(now):
 
     #test iterating by char
     response = requests.post(TWITTER_STREAMING_URL, data={'track': 'requests'},
-                            auth=('username', 'password'), stream=True)
+                             auth=('username', 'password'), stream=True)
 
     twitter_expected_response_body = b''.join(twitter_response_lines)
     with in_time(0.02, 'Iterating by char is taking forever!'):


### PR DESCRIPTION
The w3af project uses httpretty for unittesting. [Some tests were really unstable](https://github.com/andresriancho/w3af/issues/10748) (failing once every 10 runs) and I was able to track this down to the `Entry` class.

This pull request fixes the thread safety issue with the Entry class by creating a new instance for each HTTP request. Not the best in performance, but it works and leaves the rest of the code untouched.

There seems to be an issue with `make unit functional` , where one of the tests which uses `streaming` is failing. Sadly I don't have time to learn what streaming is all about, so I'm sending this PR anyways, hoping that it will be fixed by one of the maintainers before being merged.
