### PR TITLE
Remove generic dependencies and favor the pins

### DIFF
--- a/requirements/dev.txt
+++ b/requirements/dev.txt
@@ -1,9 +1,5 @@
 -r use.txt
-coverage
 tox
 markment
 steadymark
-nose
 rednose
-mock
-sure


### PR DESCRIPTION
This is to fix pip's error about dependencies being listed twice.