### PR TITLE
allow non-http sockets to set their own timeout

### DIFF
--- a/httpretty/core.py
+++ b/httpretty/core.py
@@ -451,6 +451,9 @@ class fakesock(object):
 
         def settimeout(self, new_timeout):
             self.timeout = new_timeout
+            if not self.is_http:
+                if self.truesock:
+                    self.truesock.settimeout(new_timeout)
 
         def send(self, *args, **kwargs):
             return self.debug('send', *args, **kwargs)


### PR DESCRIPTION
I have some tests that rely on some non-http network clients timing out as opposed to blocking forever. To achieve this, they must _really_ set their timeouts.
