### PR TITLE
Python 3.x compatibility fix

### DIFF
--- a/httpretty/core.py
+++ b/httpretty/core.py
@@ -882,7 +882,7 @@ class httpretty(HttpBaseClass):
     def match_uriinfo(cls, info):
         items = sorted(
             cls._entries.items(),
-            key=lambda (matcher, _): matcher.priority,
+            key=lambda matcher_entries: matcher_entries[0].priority,
             reverse=True,
         )
         for matcher, value in items:


### PR DESCRIPTION
Tuple unpacking removed as of 3.0, see PEP 3113.