### PR TITLE
BF: no need to byte_type an in which later %s-ed, assume sending bytes registers bytes

### DIFF
--- a/httpretty/core.py
+++ b/httpretty/core.py
@@ -652,7 +652,7 @@ class Entry(BaseClass):
                                        'text/plain; charset=utf-8')
 
             content_length = headers.pop('content-length',
-                                         byte_type(self.body_length))
+                                         self.body_length)
 
             string_list.append('content-type: %s' % content_type)
             if not self.streaming:

--- a/tests/unit/test_core.py
+++ b/tests/unit/test_core.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python
+# #!/usr/bin/env python
 # -*- coding: utf-8 -*-
 from __future__ import unicode_literals
 import json
@@ -566,8 +566,8 @@ def test_fakesock_socket_sendall_with_body_data_with_entry(POTENTIAL_HTTP_PORTS,
     # When I try to send data
     socket.sendall(b"BLABLABLABLA")
 
-    # Then it shoud have called real_sendall
-    data_sent.should.equal(['BLABLABLABLA'])
+    # Then it should have called real_sendall
+    data_sent.should.equal([b'BLABLABLABLA'])
 
 
 @patch('httpretty.core.httpretty.match_uriinfo')


### PR DESCRIPTION
also adjusted bogus shebang to not be real as in other files