### PR TITLE
Remove the false Python3 support classifier

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -107,8 +107,6 @@ setup(
         'Programming Language :: Python :: 2',
         'Programming Language :: Python :: 2.6',
         'Programming Language :: Python :: 2.7',
-        'Programming Language :: Python :: 3',
-        'Programming Language :: Python :: 3.4',
         'Programming Language :: Python',
         'Topic :: Internet :: WWW/HTTP',
         'Topic :: Software Development :: Testing'


### PR DESCRIPTION
As the readme states:

    Due to big API incompatibility between python 3.3, 3.4 and 3.5, the author of
    HTTPretty is not supporting python3 officially. You will notice that the travis
    build for python 3 might be broken, and while pull requests fixing py3 support
    are most welcome, it is still not official at least for now.

it is preferable to not advertise support when it doesn't practically exist.