### PR TITLE
Encode callable body length as str and not bytes

### DIFF
--- a/httpretty/core.py
+++ b/httpretty/core.py
@@ -637,7 +637,7 @@ class Entry(BaseClass):
                 headers
             )
             headers.update({
-                'content-length': byte_type(len(self.body))
+                'content-length': text_type(len(self.body))
             })
 
         string_list = [

--- a/tests/unit/test_httpretty.py
+++ b/tests/unit/test_httpretty.py
@@ -276,6 +276,16 @@ def test_Entry_class_counts_multibyte_characters_in_bytes():
     expect(b'content-length: 15\n').to.be.within(response)
 
 
+def test_Entry_class_counts_dynamic():
+    result = (200, {}, 'こんにちは'.encode('utf-8'))
+    entry = Entry(HTTPretty.GET, 'http://example.com', lambda *args: result)
+    entry.info = URIInfo.from_uri('http://example.com', entry)
+    buf = FakeSockFile()
+    entry.fill_filekind(buf)
+    response = buf.getvalue()
+    expect(b'content-length: 15\n').to.be.within(response)
+
+
 def test_fake_socket_passes_through_setblocking():
     import socket
     HTTPretty.enable()


### PR DESCRIPTION
The bytes() constructor, when given an integer, creates a
bytes object of that length, instead of casting the number to a
string representation. This change uses str() to cast the integer,
and then relies on the later utf8() call to convert it to bytes.