### PR TITLE
ndg fix

### DIFF
--- a/httpretty/__init__.py
+++ b/httpretty/__init__.py
@@ -25,7 +25,7 @@
 # OTHER DEALINGS IN THE SOFTWARE.
 from __future__ import unicode_literals
 
-__version__ = version = '0.8.14'
+__version__ = version = '0.8.15'
 
 from .core import httpretty, httprettified, EmptyRequestHeaders
 from .errors import HTTPrettyError, UnmockedError

--- a/httpretty/core.py
+++ b/httpretty/core.py
@@ -101,6 +101,13 @@ try:  # pragma: no cover
 except ImportError:  # pragma: no cover
     ssl = None
 
+# used to handle error caused by ndg-httpsclient
+try:
+    from requests.packages.urllib3.contrib.pyopenssl import inject_into_urllib3, extract_from_urllib3
+    pyopenssl_override = True
+except:
+    pyopenssl_override = False
+
 
 DEFAULT_HTTP_PORTS = frozenset([80])
 POTENTIAL_HTTP_PORTS = set(DEFAULT_HTTP_PORTS)
@@ -1067,6 +1074,10 @@ class httpretty(HttpBaseClass):
                 ssl.sslwrap_simple = old_sslwrap_simple
                 ssl.__dict__['sslwrap_simple'] = old_sslwrap_simple
 
+        if pyopenssl_override:
+            # Put the pyopenssl version back in place
+            inject_into_urllib3()
+
     @classmethod
     def is_enabled(cls):
         return cls._is_enabled
@@ -1112,6 +1123,10 @@ class httpretty(HttpBaseClass):
             if not PY3:
                 ssl.sslwrap_simple = fake_wrap_socket
                 ssl.__dict__['sslwrap_simple'] = fake_wrap_socket
+
+        if pyopenssl_override:
+            # Take out the pyopenssl version - use the default implementation
+            extract_from_urllib3()
 
 
 class httprettized(object):


### PR DESCRIPTION
made changes to versioning info as well as added an import with conditional usage of inject_into/extract_from urllib3 to allow ndg-httpsclient==0.4.0 to be present at the same time as httpretty
