### PR TITLE
Pass `tests_require` list of packages

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -83,6 +83,8 @@ local_file = lambda *f: \
 
 install_requires, dependency_links = \
     parse_requirements('requirements.txt')
+tests_requires, tests_dependency_links = \
+    parse_requirements('development.txt')
 
 
 setup(
@@ -95,7 +97,7 @@ setup(
     url='http://github.com/gabrielfalcao/httpretty',
     zip_safe=False,
     packages=find_packages(exclude=['*tests*']),
-    tests_require=parse_requirements('development.txt'),
+    tests_require=tests_requires,
     install_requires=install_requires,
     dependency_links=dependency_links,
     license='MIT',


### PR DESCRIPTION
`tests_require` accepts a list of packages, while it was being passed a tuple of packages and dependency links.