### PR TITLE
Expose httpretty.latest_requests

### DIFF
--- a/README.md
+++ b/README.md
@@ -442,6 +442,21 @@ urllib2.urlopen('http://www.google.com')
 urllib2.urlopen.when.called_with('http://www.reddit.com').should.have.raised(httpretty.errors.UnmockedError)
 ```
 
+## checking multiple responses
+```python
+@httpretty.activate
+def test_post_bodies():
+    url = 'http://httpbin.org/post'
+    httpretty.register_uri(httpretty.POST, url, status=200)
+    httpretty.register_uri(httpretty.POST, url, status=400)
+
+    requests.post(url, data={'foo': 'bar'})
+    requests.post(url, data={'zoo': 'zoo'})
+
+    assert 'foo=bar' in httpretty.latest_requests()[0].body
+    assert 'zoo=bar' in httpretty.latest_requests()[1].body
+```
+
 # Motivation
 
 When building systems that access external resources such as RESTful

--- a/README.rst
+++ b/README.rst
@@ -469,6 +469,24 @@ raising an error if an unregistered endpoint is requested
     urllib2.urlopen('http://www.google.com')
     urllib2.urlopen.when.called_with('http://www.reddit.com').should.have.raised(httpretty.errors.UnmockedError)
 
+checking multiple responses
+---------------------------
+
+.. code:: python
+
+    @httpretty.activate
+    def test_post_bodies():
+        url = 'http://httpbin.org/post'
+        httpretty.register_uri(httpretty.POST, url, status=200)
+        httpretty.register_uri(httpretty.POST, url, status=400)
+
+        requests.post(url, data={'foo': 'bar'})
+        requests.post(url, data={'zoo': 'zoo'})
+
+        assert 'foo=bar' in httpretty.latest_requests()[0].body
+        assert 'zoo=bar' in httpretty.latest_requests()[1].body
+
+
 Motivation
 ==========
 

--- a/httpretty/__init__.py
+++ b/httpretty/__init__.py
@@ -56,6 +56,11 @@ def last_request():
     return httpretty.last_request
 
 
+def latest_requests():
+    """returns the history of made requests"""
+    return httpretty.latest_requests
+
+
 def has_request():
     """returns a boolean indicating whether any request has been made"""
     return not isinstance(httpretty.last_request.headers, EmptyRequestHeaders)

--- a/tests/unit/test_main.py
+++ b/tests/unit/test_main.py
@@ -13,6 +13,13 @@ def test_last_request(original):
     httpretty.last_request().should.equal(original.last_request)
 
 
+@patch('httpretty.httpretty')
+def test_last_request(original):
+    ("httpretty.latest_requests() should return httpretty.core.latest_requests")
+
+    httpretty.latest_requests().should.equal(original.latest_requests)
+
+
 def test_has_request():
     ("httpretty.has_request() correctly detects "
      "whether or not a request has been made")


### PR DESCRIPTION
This is typically accessible by `from httpretty import httpretty` but I think it may be worth exposing it through the main API as well.

Closes #270 and #155.