### PR TITLE
Add python 3 to setup.py classifiers

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -109,6 +109,8 @@ setup(
         'Programming Language :: Python :: 2',
         'Programming Language :: Python :: 2.6',
         'Programming Language :: Python :: 2.7',
+        'Programming Language :: Python :: 3',
+        'Programming Language :: Python :: 3.5',
         'Programming Language :: Python',
         'Topic :: Internet :: WWW/HTTP',
         'Topic :: Software Development :: Testing'


### PR DESCRIPTION
Tools like [requires.io](https://requires.io/) recognize Python 3 by reading classifiers.

Added only python 3.5 since it is tested with tox.