### PR TITLE
Call reset from setUp and tearDown in addition to enable and disable.

### DIFF
--- a/httpretty/core.py
+++ b/httpretty/core.py
@@ -1189,6 +1189,7 @@ def httprettified(test):
                           if hasattr(klass, 'setUp')
                           else None)
         def new_setUp(self):
+            httpretty.reset()
             httpretty.enable()
             if use_addCleanup:
                 self.addCleanup(httpretty.disable)
@@ -1202,6 +1203,7 @@ def httprettified(test):
                                  else None)
             def new_tearDown(self):
                 httpretty.disable()
+                httpretty.reset()
                 if original_tearDown:
                     original_tearDown(self)
             klass.tearDown = new_tearDown


### PR DESCRIPTION
When decorating a class via setUp and tearDown, reset() was not being
called.  That was an unintentional change in behavior from previous versions.

Addresses #316.