### PR TITLE
Update version classifiers

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -13,3 +13,4 @@ _public/
 tests/functional/fixtures/recording-*.json
 #*
 *#*
+.idea

--- a/httpretty/core.py
+++ b/httpretty/core.py
@@ -211,7 +211,7 @@ class HTTPrettyRequest(BaseHTTPRequestHandler, BaseClass):
         return bool(self.body) or bool(self.raw_headers)
 
     def __str__(self):
-        tmpl = '<HTTPrettyRequest("{0}", total_headers={1}, body_length={2})>'
+        tmpl = '<HTTPrettyRequest("{}", total_headers={}, body_length={})>'
         return tmpl.format(
             self.headers.get('content-type', ''),
             len(self.headers),
@@ -706,7 +706,7 @@ class Entry(BaseClass):
 
         for k, v in headers.items():
             string_list.append(
-                '{0}: {1}'.format(k, v),
+                '{}: {}'.format(k, v),
             )
 
         for item in string_list:
@@ -795,12 +795,12 @@ class URIInfo(BaseClass):
     def full_url(self, use_querystring=True):
         credentials = ""
         if self.password:
-            credentials = "{0}:{1}@".format(
+            credentials = "{}:{}@".format(
                 self.username, self.password)
 
         query = ""
         if use_querystring and self.query:
-            query = "?{0}".format(decode_utf8(self.query))
+            query = "?{}".format(decode_utf8(self.query))
 
         result = "{scheme}://{credentials}{domain}{path}{query}".format(
             scheme=self.scheme,
@@ -870,7 +870,7 @@ class URIMatcher(object):
                 use_querystring=self._match_querystring))
 
     def __str__(self):
-        wrap = 'URLMatcher({0})'
+        wrap = 'URLMatcher({})'
         if self.info:
             return wrap.format(text_type(self.info))
         else:

--- a/setup.py
+++ b/setup.py
@@ -107,8 +107,8 @@ setup(
         'Intended Audience :: Developers',
         'License :: OSI Approved :: MIT License',
         'Programming Language :: Python :: 2',
-        'Programming Language :: Python :: 2.6',
         'Programming Language :: Python :: 2.7',
+        'Programming Language :: Python :: 2 :: Only',
         'Programming Language :: Python',
         'Topic :: Internet :: WWW/HTTP',
         'Topic :: Software Development :: Testing'

--- a/setup.py
+++ b/setup.py
@@ -69,7 +69,7 @@ def parse_requirements(path):
         if 'http:' in req or 'https:' in req:
             links.append(req)
             name, version = re.findall("\#egg=([^\-]+)-(.+$)", req)[0]
-            pkgs.append('{0}=={1}'.format(name, version))
+            pkgs.append('{}=={}'.format(name, version))
         else:
             pkgs.append(req)
 

--- a/tests/functional/test_bypass.py
+++ b/tests/functional/test_bypass.py
@@ -54,7 +54,7 @@ def start_http_server(context):
         httpretty.disable()
         time.sleep(.1)
         try:
-            requests.get('http://localhost:{0}/'.format(context.http_port))
+            requests.get('http://localhost:{}/'.format(context.http_port))
             ready = True
         except:
             if time.time() - started_at >= timeout:
@@ -88,19 +88,19 @@ def test_httpretty_bypasses_when_disabled(context):
     "httpretty should bypass all requests by disabling it"
 
     httpretty.register_uri(
-        httpretty.GET, "http://localhost:{0}/go-for-bubbles/".format(context.http_port),
+        httpretty.GET, "http://localhost:{}/go-for-bubbles/".format(context.http_port),
         body="glub glub")
 
     httpretty.disable()
 
-    fd = urllib2.urlopen('http://localhost:{0}/go-for-bubbles/'.format(context.http_port))
+    fd = urllib2.urlopen('http://localhost:{}/go-for-bubbles/'.format(context.http_port))
     got1 = fd.read()
     fd.close()
 
     expect(got1).to.equal(
         b'. o O 0 O o . o O 0 O o . o O 0 O o . o O 0 O o . o O 0 O o .')
 
-    fd = urllib2.urlopen('http://localhost:{0}/come-again/'.format(context.http_port))
+    fd = urllib2.urlopen('http://localhost:{}/come-again/'.format(context.http_port))
     got2 = fd.read()
     fd.close()
 
@@ -108,7 +108,7 @@ def test_httpretty_bypasses_when_disabled(context):
 
     httpretty.enable()
 
-    fd = urllib2.urlopen('http://localhost:{0}/go-for-bubbles/'.format(context.http_port))
+    fd = urllib2.urlopen('http://localhost:{}/go-for-bubbles/'.format(context.http_port))
     got3 = fd.read()
     fd.close()
 
@@ -122,16 +122,16 @@ def test_httpretty_bypasses_a_unregistered_request(context):
     "httpretty should bypass a unregistered request by disabling it"
 
     httpretty.register_uri(
-        httpretty.GET, "http://localhost:{0}/go-for-bubbles/".format(context.http_port),
+        httpretty.GET, "http://localhost:{}/go-for-bubbles/".format(context.http_port),
         body="glub glub")
 
-    fd = urllib2.urlopen('http://localhost:{0}/go-for-bubbles/'.format(context.http_port))
+    fd = urllib2.urlopen('http://localhost:{}/go-for-bubbles/'.format(context.http_port))
     got1 = fd.read()
     fd.close()
 
     expect(got1).to.equal(b'glub glub')
 
-    fd = urllib2.urlopen('http://localhost:{0}/come-again/'.format(context.http_port))
+    fd = urllib2.urlopen('http://localhost:{}/come-again/'.format(context.http_port))
     got2 = fd.read()
     fd.close()
 
@@ -182,7 +182,7 @@ def test_disallow_net_connect_1(context):
     def foo():
         fd = None
         try:
-            fd = urllib2.urlopen('http://localhost:{0}/go-for-bubbles/'.format(context.http_port))
+            fd = urllib2.urlopen('http://localhost:{}/go-for-bubbles/'.format(context.http_port))
         finally:
             if fd:
                 fd.close()

--- a/tests/functional/test_httplib2.py
+++ b/tests/functional/test_httplib2.py
@@ -269,7 +269,7 @@ def test_callback_response(now):
       " httplib2")
 
     def request_callback(request, uri, headers):
-        return [200,headers,"The {0} response from {1}".format(decode_utf8(request.method), uri)]
+        return [200,headers,"The {} response from {}".format(decode_utf8(request.method), uri)]
 
     HTTPretty.register_uri(
         HTTPretty.GET, "https://api.yahoo.com/test",

--- a/tests/functional/test_requests.py
+++ b/tests/functional/test_requests.py
@@ -52,7 +52,7 @@ except NameError:
         return it.next()
 next = advance_iterator
 
-server_url = lambda path, port: "http://localhost:{0}/{1}".format(port, path.lstrip('/'))
+server_url = lambda path, port: "http://localhost:{}/{}".format(port, path.lstrip('/'))
 
 
 @httprettified
@@ -427,7 +427,7 @@ def test_callback_response(now):
      " requests")
 
     def request_callback(request, uri, headers):
-        return [200, headers,"The {0} response from {1}".format(decode_utf8(request.method), uri)]
+        return [200, headers,"The {} response from {}".format(decode_utf8(request.method), uri)]
 
     HTTPretty.register_uri(
         HTTPretty.GET, "https://api.yahoo.com/test",
@@ -455,7 +455,7 @@ def test_callback_body_remains_callable_for_any_subsequent_requests(now):
      " requests")
 
     def request_callback(request, uri, headers):
-        return [200, headers,"The {0} response from {1}".format(decode_utf8(request.method), uri)]
+        return [200, headers,"The {} response from {}".format(decode_utf8(request.method), uri)]
 
     HTTPretty.register_uri(
         HTTPretty.GET, "https://api.yahoo.com/test",
@@ -475,7 +475,7 @@ def test_callback_setting_headers_and_status_response(now):
 
     def request_callback(request, uri, headers):
         headers.update({'a':'b'})
-        return [418,headers,"The {0} response from {1}".format(decode_utf8(request.method), uri)]
+        return [418,headers,"The {} response from {}".format(decode_utf8(request.method), uri)]
 
     HTTPretty.register_uri(
         HTTPretty.GET, "https://api.yahoo.com/test",
@@ -790,7 +790,7 @@ def test_py26_callback_response():
     from mock import Mock
 
     def _request_callback(request, uri, headers):
-        return [200, headers,"The {0} response from {1}".format(decode_utf8(request.method), uri)]
+        return [200, headers,"The {} response from {}".format(decode_utf8(request.method), uri)]
 
     request_callback = Mock()
     request_callback.side_effect = _request_callback

--- a/tests/functional/test_urllib2.py
+++ b/tests/functional/test_urllib2.py
@@ -289,7 +289,7 @@ def test_callback_response(now):
       " urllib2")
 
     def request_callback(request, uri, headers):
-        return [200, headers, "The {0} response from {1}".format(decode_utf8(request.method), uri)]
+        return [200, headers, "The {} response from {}".format(decode_utf8(request.method), uri)]
 
     HTTPretty.register_uri(
         HTTPretty.GET, "https://api.yahoo.com/test",


### PR DESCRIPTION
Python 2.6 is EOL and was dropped in 2015 in https://github.com/gabrielfalcao/HTTPretty/commit/55e26ec70cc6afbfc7fd98e3c59fad697fb9f656, which is good as it's EOL, so this updates the Trove classifiers in setup.py.

We can also use automatic formatters (https://pyformat.info/), available from 2.7+.