### PR TITLE
Fixing issue with random binary data sent in the query string.

### DIFF
--- a/httpretty/compat.py
+++ b/httpretty/compat.py
@@ -72,7 +72,7 @@ except ImportError:  # pragma: no cover
             qs = qs.encode('utf-8')
         s = unquote(qs)
         if isinstance(s, byte_type):
-            return s.decode("utf-8")
+            return s.decode('utf-8', errors='ignore')
         else:
             return s
 


### PR DESCRIPTION
I identified an issue with httpretty which looks like this:

```
  File "/usr/lib/python2.7/httplib.py", line 1053, in endheaders
    self._send_output(message_body)
  File "/usr/lib/python2.7/httplib.py", line 897, in _send_output
    self.send(msg)
  File "/usr/lib/python2.7/httplib.py", line 873, in send
    self.sock.sendall(data)
  File "/home/user/tools/virtualenvs/w3af/local/lib/python2.7/site-packages/httpretty/core.py", line 442, in sendall
    request = httpretty.historify_request(headers, body)
  File "/home/user/tools/virtualenvs/w3af/local/lib/python2.7/site-packages/httpretty/core.py", line 969, in historify_request
    request = HTTPrettyRequest(headers, body)
  File "/home/user/tools/virtualenvs/w3af/local/lib/python2.7/site-packages/httpretty/core.py", line 183, in __init__
    self.querystring = self.parse_querystring(qstring)
  File "/home/user/tools/virtualenvs/w3af/local/lib/python2.7/site-packages/httpretty/core.py", line 201, in parse_querystring
    expanded = unquote_utf8(qs)
  File "/home/user/tools/virtualenvs/w3af/local/lib/python2.7/site-packages/httpretty/compat.py", line 75, in unquote_utf8
    return s.decode("utf-8")
  File "/home/user/tools/virtualenvs/w3af/lib/python2.7/encodings/utf_8.py", line 16, in decode
    return codecs.utf_8_decode(input, errors, True)
']
```

The problem is that `return s.decode("utf-8")` is trying to decode a string of bytes which is not valid utf-8. I found that while sending some random binary data via my HTTP client.

The fix below is not perfect, since some bytes might be removed from the original `s` string when there is a decoding issue, but it will fix the issue and go unnoticed for 99% of the users