### PR TITLE
Bugfix/match query params

### DIFF
--- a/httpretty/core.py
+++ b/httpretty/core.py
@@ -991,7 +991,8 @@ class URIMatcher(object):
 
     def matches(self, info):
         if self.info:
-            return self.info == info
+            # Query string is not considered when comparing info objects, compare separately
+            return self.info == info and (not self._match_querystring or self.info.query == info.query)
         else:
             return self.regex.search(info.full_url(
                 use_querystring=self._match_querystring))

--- a/tests/unit/test_core.py
+++ b/tests/unit/test_core.py
@@ -10,6 +10,7 @@ from sure import expect
 
 from httpretty.compat import StringIO
 from httpretty.core import HTTPrettyRequest, FakeSSLSocket, fakesock, httpretty
+from httpretty.core import URIMatcher, URIInfo
 
 
 class SocketErrorStub(Exception):
@@ -607,3 +608,18 @@ def test_fakesock_socket_sendall_with_body_data_with_chunked_entry(POTENTIAL_HTT
 
     # Then the entry should have that body
     httpretty.last_request.body.should.equal(b'BLABLABLABLA')
+
+
+def test_URIMatcher_respects_querystring():
+    ("URIMatcher response querystring")
+    matcher = URIMatcher('http://www.foo.com/?query=true', None)
+    info = URIInfo.from_uri('http://www.foo.com/', None)
+    assert matcher.matches(info)
+
+    matcher = URIMatcher('http://www.foo.com/?query=true', None, match_querystring=True)
+    info = URIInfo.from_uri('http://www.foo.com/', None)
+    assert not matcher.matches(info)
+
+    matcher = URIMatcher('http://www.foo.com/?query=true', None, match_querystring=True)
+    info = URIInfo.from_uri('http://www.foo.com/?query=true', None)
+    assert matcher.matches(info)


### PR DESCRIPTION
Here is a potential fix for the URIMatcher ignoring the match_querystring parameter
potentially addressing issue 306