### PR TITLE
Make sure URIMatcher equality check respects querystring when match_querystring is True

### DIFF
--- a/httpretty/core.py
+++ b/httpretty/core.py
@@ -851,6 +851,14 @@ class URIInfo(BaseClass):
     :param scheme:
     :param last_request:
     """
+    default_str_attrs = (
+        'username',
+        'password',
+        'hostname',
+        'port',
+        'path',
+    )
+
     def __init__(self,
                  username='',
                  password='',
@@ -884,16 +892,16 @@ class URIInfo(BaseClass):
         self.fragment = fragment or ''
         self.last_request = last_request
 
-    def __str__(self):
-        attrs = (
-            'username',
-            'password',
-            'hostname',
-            'port',
-            'path',
-        )
+    def to_str(self, attrs):
         fmt = ", ".join(['%s="%s"' % (k, getattr(self, k, '')) for k in attrs])
         return r'<httpretty.URIInfo(%s)>' % fmt
+
+    def __str__(self):
+        return self.to_str(self.default_str_attrs)
+
+    def str_with_query(self):
+        attrs = self.default_str_attrs + ('query',)
+        return self.to_str(attrs)
 
     def __hash__(self):
         return int(hashlib.sha1(binary_type(self, 'ascii')).hexdigest(), 16)
@@ -1004,7 +1012,10 @@ class URIMatcher(object):
     def __str__(self):
         wrap = 'URLMatcher({})'
         if self.info:
-            return wrap.format(text_type(self.info))
+            if self._match_querystring:
+                return wrap.format(text_type(self.info.str_with_query()))
+            else:
+                return wrap.format(text_type(self.info))
         else:
             return wrap.format(self.regex.pattern)
 

--- a/tests/unit/test_core.py
+++ b/tests/unit/test_core.py
@@ -623,3 +623,22 @@ def test_URIMatcher_respects_querystring():
     matcher = URIMatcher('http://www.foo.com/?query=true', None, match_querystring=True)
     info = URIInfo.from_uri('http://www.foo.com/?query=true', None)
     assert matcher.matches(info)
+
+
+def test_URIMatcher_equality_respects_querystring():
+    ("URIMatcher equality check should check querystring")
+    matcher_a = URIMatcher('http://www.foo.com/?query=true', None)
+    matcher_b = URIMatcher('http://www.foo.com/?query=false', None)
+    assert matcher_a == matcher_b
+
+    matcher_a = URIMatcher('http://www.foo.com/?query=true', None)
+    matcher_b = URIMatcher('http://www.foo.com/', None)
+    assert matcher_a == matcher_b
+
+    matcher_a = URIMatcher('http://www.foo.com/?query=true', None, match_querystring=True)
+    matcher_b = URIMatcher('http://www.foo.com/?query=false', None, match_querystring=True)
+    assert not matcher_a == matcher_b
+
+    matcher_a = URIMatcher('http://www.foo.com/?query=true', None, match_querystring=True)
+    matcher_b = URIMatcher('http://www.foo.com/', None, match_querystring=True)
+    assert not matcher_a == matcher_b


### PR DESCRIPTION
This was needed to fix a problem I had where I tried to register the same url with different query strings and httpretty always returned the response for the last one I registered.

