### PR TITLE
test for query string ordering WIP

### DIFF
--- a/tests/unit/test_core.py
+++ b/tests/unit/test_core.py
@@ -624,6 +624,10 @@ def test_URIMatcher_respects_querystring():
     info = URIInfo.from_uri('http://www.foo.com/?query=true', None)
     assert matcher.matches(info)
 
+    matcher = URIMatcher('http://www.foo.com/?query=true&unquery=false', None, match_querystring=True)
+    info = URIInfo.from_uri('http://www.foo.com/?unquery=false&query=true', None)
+    assert matcher.matches(info)
+
 
 def test_URIMatcher_equality_respects_querystring():
     ("URIMatcher equality check should check querystring")


### PR DESCRIPTION
Looks like there is also an issue with query string ordering. Should query string params be considered unordered? I think so. Wrote this test to verify the problem - will work on a solution later.

I ran in to this because tests pass locally and fail on our CI system because the query param ordering changes. FYI @ErwinJunge 