### PR TITLE
Make sure the hostname part of a uri can be a regex

### DIFF
--- a/httpretty/core.py
+++ b/httpretty/core.py
@@ -88,6 +88,7 @@ old_sslsocket = None
 old_sslcontext_wrap_socket = None
 
 MULTILINE_ANY_REGEX = re.compile(r'.*', re.M)
+hostname_re = re.compile(r'\^?(?:https?://)?[^:/]*[:/]?')
 
 
 try:  # pragma: no cover
@@ -1099,9 +1100,13 @@ class httpretty(HttpBaseClass):
             if matcher.info is None:
                 pattern_with_port = "https://{0}:".format(hostname)
                 pattern_without_port = "https://{0}/".format(hostname)
+                hostname_pattern = (
+                    hostname_re
+                    .match(matcher.regex.pattern)
+                    .group(0)
+                )
                 for pattern in [pattern_with_port, pattern_without_port]:
-                    if matcher.regex.search(pattern) is not None \
-                            or matcher.regex.pattern.startswith(pattern):
+                    if re.match(hostname_pattern, pattern):
                         return matcher
 
             elif matcher.info.hostname == hostname:
@@ -1129,9 +1134,13 @@ class httpretty(HttpBaseClass):
 
                 pattern_without_port = "{0}{1}/".format(scheme, hostname)
                 pattern_with_port = "{0}{1}:{2}/".format(scheme, hostname, port)
+                hostname_pattern = (
+                    hostname_re
+                    .match(matcher.regex.pattern)
+                    .group(0)
+                )
                 for pattern in [pattern_with_port, pattern_without_port]:
-                    if matcher.regex.search(pattern_without_port) is not None \
-                            or matcher.regex.pattern.startswith(pattern):
+                    if re.match(hostname_pattern, pattern):
                         return matcher
 
             elif matcher.info.hostname == hostname \

--- a/tests/unit/test_httpretty.py
+++ b/tests/unit/test_httpretty.py
@@ -25,6 +25,7 @@
 # FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR
 # OTHER DEALINGS IN THE SOFTWARE.
 from __future__ import unicode_literals
+import re
 import json
 from sure import expect
 import httpretty
@@ -447,3 +448,27 @@ def test_socktype_good_python_version():
         HTTPretty.enable()
         expect(socket.SocketType).to.equal(socket.socket)
         HTTPretty.disable()
+
+
+def test_httpretty_should_allow_registering_regex_hostnames():
+    "HTTPretty should allow registering regexes with requests"
+
+    HTTPretty.register_uri(
+        HTTPretty.GET,
+        re.compile(r'^http://\w+\.foo\.com/baz$'),
+        body="yay",
+    )
+
+    assert HTTPretty.match_http_address('www.foo.com', 80)
+
+
+def test_httpretty_should_allow_registering_regex_hostnames_ssl():
+    "HTTPretty should allow registering regexes with requests (ssl version)"
+
+    HTTPretty.register_uri(
+        HTTPretty.GET,
+        re.compile(r'^https://\w+\.foo\.com/baz$'),
+        body="yay",
+    )
+
+    assert HTTPretty.match_https_hostname('www.foo.com')


### PR DESCRIPTION
This solves a problem I had where the subdomain of my request was covered by a regex. Without the code in this PR that didn't work. See the added tests for a cut-down artificial example of the original problem.