### PR TITLE
Avoid hardcoding socket family, type and protocol

### DIFF
--- a/httpretty/core.py
+++ b/httpretty/core.py
@@ -638,7 +638,8 @@ def fake_gethostname():
 def fake_getaddrinfo(
         host, port, family=None, socktype=None, proto=None, flags=None):
     """drop-in replacement for :py:func:`socket.getaddrinfo`"""
-    return [(2, 1, 6, '', (host, port))]
+    return [(socket.AF_INET, socket.SOCK_STREAM, socket.IPPROTO_TCP,
+             '', (host, port))]
 
 
 class Entry(BaseClass):


### PR DESCRIPTION
SOCK_DGRAM and SOCK_STREAM are system-specific constants,
so we should use the constants from socket module instead
of having their value right in the code.

Closes: #358