### PR TITLE
Double.slashes

### DIFF
--- a/httpretty/core.py
+++ b/httpretty/core.py
@@ -527,6 +527,8 @@ class fakesock(object):
                     httpretty.historify_request(headers, body, False)
                     return
 
+            if path[:2] == '//':
+                path = '//' + path
             # path might come with
             s = urlsplit(path)
             POTENTIAL_HTTP_PORTS.add(int(s.port or 80))

--- a/httpretty/core.py
+++ b/httpretty/core.py
@@ -609,7 +609,7 @@ def fake_wrap_socket(orig_wrap_socket_fn, *args, **kw):
     if server_hostname is not None:
         matcher = httpretty.match_https_hostname(server_hostname)
         if matcher is None:
-                return orig_wrap_socket_fn(*args, **kw)
+            return orig_wrap_socket_fn(*args, **kw)
     if 'sock' in kw:
         return kw['sock']
     else:

--- a/tests/functional/test_requests.py
+++ b/tests/functional/test_requests.py
@@ -910,3 +910,18 @@ def test_httpretty_should_allow_registering_regexes_with_port_and_give_a_proper_
     expect(response.text).to.equal('https://api.yipit.com:1234/v1/deal;brand=gap?first_name=chuck&last_name=norris')
     expect(HTTPretty.last_request.method).to.equal('GET')
     expect(HTTPretty.last_request.path).to.equal('/v1/deal;brand=gap?first_name=chuck&last_name=norris')
+
+
+@httprettified
+def test_httpretty_should_handle_paths_starting_with_two_slashes():
+    "HTTPretty should handle URLs with paths starting with //"
+
+    HTTPretty.register_uri(
+        HTTPretty.GET, "http://example.com//foo",
+        body="Find the best foo"
+    )
+
+    response = requests.get('http://example.com//foo')
+    expect(response.text).to.equal('Find the best foo')
+    expect(HTTPretty.last_request.method).to.equal('GET')
+    expect(HTTPretty.last_request.path).to.equal('//foo')

--- a/tests/unit/test_core.py
+++ b/tests/unit/test_core.py
@@ -610,6 +610,25 @@ def test_fakesock_socket_sendall_with_body_data_with_chunked_entry(POTENTIAL_HTT
     httpretty.last_request.body.should.equal(b'BLABLABLABLA')
 
 
+def test_fakesock_socket_sendall_with_path_starting_with_two_slashes():
+    ("fakesock.socket#sendall handles paths starting with // well")
+
+    httpretty.register_uri(httpretty.GET, 'http://example.com//foo')
+
+    class MySocket(fakesock.socket):
+        def real_sendall(self, data, *args, **kw):
+            raise AssertionError('should never call this...')
+
+    # Given an instance of that socket
+    socket = MySocket()
+
+    # And that is is considered http
+    socket.connect(('example.com', 80))
+
+    # When I try to send data
+    socket.sendall(b"GET //foo HTTP/1.1\r\nContent-Type: application/json\r\n\r\n")
+
+
 def test_URIMatcher_respects_querystring():
     ("URIMatcher response querystring")
     matcher = URIMatcher('http://www.foo.com/?query=true', None)


### PR DESCRIPTION
This pull request fixes #318.

`urlsplit()` is used to parse the URL in the request line, but the specification of that URL - a request target - in HTTP RFC 7230 is different from URI specification (RFC 3986) on which `urlsplit()` is based.

In particular addresses starting with two slashes are interpreted differently, e.g. `//foo/bar` is just a path for HTTP servers, but it's a `/bar` at `foo` server for `urlsplit()`. To fix it, I prepend another `//` at the beginning of the path if it starts with two slashes. It makes ` urlsplit()` think it's the proper path at a server with empty name, which is fine, as HTTPretty ignores the server (netloc) part anyway.
