### PR TITLE
:pencil: Clarify relation between `enabled` and `httprettized` in API docs

### DIFF
--- a/docs/source/api.rst
+++ b/docs/source/api.rst
@@ -55,6 +55,15 @@ httprettified
    :members:
 
 
+.. _enabled:
+
+enabled
+-------
+
+.. autoclass:: httpretty.enabled
+   :members:
+
+
 .. _httprettized:
 
 httprettized

--- a/httpretty/core.py
+++ b/httpretty/core.py
@@ -1567,6 +1567,8 @@ class httpretty(HttpBaseClass):
 class httprettized(object):
     """`context-manager <https://docs.python.org/3/reference/datamodel.html#context-managers>`_ for enabling HTTPretty.
 
+    .. tip:: Also available under the alias :py:func:`httpretty.enabled`
+
     .. testcode::
 
        import json


### PR DESCRIPTION
… analogous to how it's already done for `activate` and `httprettified`.