### PR TITLE
Use unittest.mock over mock when available

### DIFF
--- a/development.txt
+++ b/development.txt
@@ -5,7 +5,7 @@ freezegun
 httplib2
 ipdb
 mccabe
-mock
+mock;python_version<"3.3"
 ndg-httpsclient
 nose-randomly
 nose

--- a/setup.py
+++ b/setup.py
@@ -41,7 +41,8 @@ local_file = lambda *f: \
 
 
 install_requires = []
-tests_requires = ['nose', 'sure', 'coverage', 'mock', 'rednose']
+tests_requires = ['nose', 'sure', 'coverage', 'mock;python_version<"3.3"',
+                  'rednose']
 
 
 setup(

--- a/tests/functional/test_requests.py
+++ b/tests/functional/test_requests.py
@@ -33,7 +33,6 @@ import json
 import requests
 import signal
 from freezegun import freeze_time
-from mock import Mock
 from unittest import skip
 from contextlib import contextmanager
 from sure import within, microseconds, expect
@@ -41,8 +40,12 @@ from tornado import version as tornado_version
 from httpretty import HTTPretty, httprettified
 from httpretty.core import decode_utf8
 
-
 from tests.functional.base import FIXTURE_FILE, use_tornado_server
+
+try:
+    from unittest.mock import Mock
+except ImportError:
+    from mock import Mock
 
 
 try:

--- a/tests/unit/test_core.py
+++ b/tests/unit/test_core.py
@@ -3,11 +3,15 @@ import json
 import errno
 
 from freezegun import freeze_time
-from mock import Mock, patch, call
 from sure import expect
 
 from httpretty.core import HTTPrettyRequest, FakeSSLSocket, fakesock, httpretty
 from httpretty.core import URIMatcher, URIInfo
+
+try:
+    from unittest.mock import Mock, patch, call
+except ImportError:
+    from mock import Mock, patch, call
 
 
 class SocketErrorStub(Exception):

--- a/tests/unit/test_httpretty.py
+++ b/tests/unit/test_httpretty.py
@@ -36,11 +36,10 @@ from httpretty.core import URIInfo, BaseClass, Entry, FakeSockFile, HTTPrettyReq
 from httpretty.http import STATUSES
 
 try:
-    from mock import MagicMock
-    from mock import patch
+    from unittest.mock import MagicMock, patch
 except ImportError:
-    from unittest.mock import MagicMock
-    from unittest.mock import patch
+    from mock import MagicMock, patch
+
 
 TEST_HEADER = """
 GET /test/test.html HTTP/1.1

--- a/tests/unit/test_main.py
+++ b/tests/unit/test_main.py
@@ -1,9 +1,13 @@
 #!/usr/bin/env python
 # -*- coding: utf-8 -*-
 from __future__ import unicode_literals
-from mock import patch
 import httpretty
 from httpretty.core import HTTPrettyRequest
+
+try:
+    from unittest.mock import patch
+except ImportError:
+    from mock import patch
 
 
 @patch('httpretty.httpretty')


### PR DESCRIPTION
Use unittest.mock instead of external mock module whenever present.
This makes it possible to run tests without installing mock on Python 3.