### PR TITLE
Update python_requires in setup.py

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -59,7 +59,7 @@ setup(
     install_requires=install_requires,
     license='MIT',
     test_suite='nose.collector',
-    python_requires='>=3',
+    python_requires='>=3.6',
     classifiers=[
         'Development Status :: 5 - Production/Stable',
         'Intended Audience :: Developers',


### PR DESCRIPTION
I have a package I need to test on Python 3.4. I'm fine using the older version of `httpretty` for this, but because the `python_requires` was not set precisely for the new versions, they get installed, and don't work because they try to import `typing`.

I added a workaround with the extra restrictions in my requirements: https://github.com/scoutapp/scout_apm_python/pull/513 . But it would be better if new `httpretty` versions correctly declared which Python versions they should work with.