### PR TITLE
skip redis tests if redis package is not installed

### DIFF
--- a/tests/functional/bugfixes/test_redis.py
+++ b/tests/functional/bugfixes/test_redis.py
@@ -2,11 +2,18 @@ import os
 import requests
 import httpretty
 
-from redis import Redis
+try:
+    from redis import Redis
+except ImportError:
+    Redis = None
+
 from unittest import skipUnless
 
 
 def redis_available():
+    if Redis is None:
+        return False
+
     params = dict(
         host=os.getenv('REDIS_HOST') or '127.0.0.1',
         port=int(os.getenv('REDIS_PORT') or 6379)


### PR DESCRIPTION
Skip redis tests if redis is not installed.  The tests are skipped
anyway if redis server is not running, so there is no reason to
unconditionally force redis-py being installed.