### PR TITLE
Handle socket version check in urllib3>=1.26

### DIFF
--- a/httpretty/core.py
+++ b/httpretty/core.py
@@ -706,7 +706,11 @@ class fakesock(object):
                 # Special case for
                 # `hasattr(sock, "version")` call added in urllib3>=1.26.
                 if name == 'version':
-                    raise AttributeError()
+                    raise AttributeError(
+                        "HTTPretty synthesized this error to fix urllib3 compatibility "
+                        "(see issue https://github.com/gabrielfalcao/HTTPretty/issues/409). "
+                        "Please open an issue if this error causes further unexpected issues."
+                    )
                 raise UnmockedError()
             return getattr(self.truesock, name)
 

--- a/httpretty/core.py
+++ b/httpretty/core.py
@@ -703,6 +703,10 @@ class fakesock(object):
                 # calls (or can they?)
                 self.truesock = self.create_socket()
             elif not self.truesock:
+                # Special case for
+                # `hasattr(sock, "version")` call added in urllib3>=1.26.
+                if name == 'version':
+                    raise AttributeError()
                 raise UnmockedError()
             return getattr(self.truesock, name)
 


### PR DESCRIPTION
Handle [this call](https://github.com/urllib3/urllib3/blob/1.26.2/src/urllib3/connection.py#L430) added in `urllib3>=1.26`.

Fixes #409