### PR TITLE
Respect socket timeout

### DIFF
--- a/httpretty/core.py
+++ b/httpretty/core.py
@@ -1697,7 +1697,6 @@ class httpretty(HttpBaseClass):
             del cls._entries[matcher]
 
         cls._entries[matcher] = entries_for_this_uri
-        return matcher, entries_for_this_uri[:]
 
     def __str__(self):
         return '<HTTPretty with %d URI entries>' % len(self._entries)

--- a/httpretty/core.py
+++ b/httpretty/core.py
@@ -74,7 +74,7 @@ from datetime import timedelta
 from errno import EAGAIN
 
 class __internals__:
-    thread_timeout = 0  # https://github.com/gabrielfalcao/HTTPretty/issues/426
+    thread_timeout = 0.1  # https://github.com/gabrielfalcao/HTTPretty/issues/430
     temp_files = []
     threads = []
 

--- a/tests/bugfixes/nosetests/test_430_respect_timeout.py
+++ b/tests/bugfixes/nosetests/test_430_respect_timeout.py
@@ -1,0 +1,54 @@
+# This test is based on @mariojonke snippet:
+# https://github.com/gabrielfalcao/HTTPretty/issues/430
+import time
+from requests import Session
+from requests.adapters import HTTPAdapter
+from requests.exceptions import ReadTimeout
+
+from threading import Event
+
+from httpretty import httprettified
+from httpretty import HTTPretty
+
+
+def http(max_connections=1):
+    session = Session()
+    adapter = HTTPAdapter(
+        pool_connections=max_connections,
+        pool_maxsize=max_connections
+    )
+    session.mount('http://', adapter)
+    session.mount('https://', adapter)
+    return session
+
+
+
+@httprettified(verbose=True, allow_net_connect=False)
+def test_read_timeout():
+    "#430 httpretty should respect read timeout"
+    event = Event()
+    uri = "http://example.com"
+
+    #  Given that I register a uri with a callback body that delays 10 seconds
+    wait_seconds = 10
+
+    def my_callback(request, url, headers):
+        event.wait(wait_seconds)
+        return 200, headers, "Received"
+
+    HTTPretty.register_uri(HTTPretty.GET, uri, body=my_callback)
+
+    # And I use a thread pool with 1 TCP connection max
+    max_connections = 1
+    request = http(max_connections)
+    started_at = time.time()
+    # When I make an HTTP request with a read timeout of 0.1 and an indefinite connect timeout
+    when_called = request.get.when.called_with(uri, timeout=(None, 0.1))
+
+    # Then the request should have raised a connection timeout
+    when_called.should.have.raised(ReadTimeout)
+
+    # And the total execution time should be less than 0.2 seconds
+    event.set()
+    total_time = time.time() - started_at
+    total_time.should.be.lower_than(0.2)


### PR DESCRIPTION
This PR closes #430.

@mariojonke thanks for the test case, I'll mention it in a new section of "guides" in the docs.

Your test-case caught [a mistake I made](https://github.com/gabrielfalcao/HTTPretty/commit/0b74a861dedb8e4cf1574e20c7f95a5334f790b2#diff-326a996e75c88c9fc8dabbfdca5029c2a409fac6a2dd9b7dffa9f3726bce7c55R700) in fixing #428 😅 :

https://github.com/gabrielfalcao/HTTPretty/blob/19880d856d2a62c52d8b218953d742e9ba10f784/httpretty/core.py#L700
