### PR TITLE
Fallback to WARNING when logging.getLogger().level is None

### DIFF
--- a/httpretty/core.py
+++ b/httpretty/core.py
@@ -1815,7 +1815,7 @@ class httpretty(HttpBaseClass):
         if verbose:
             logger.setLevel(logging.DEBUG)
         else:
-            logger.setLevel(logging.getLogger().level)
+            logger.setLevel(logging.getLogger().level or logging.WARNING)
 
 
 def apply_patch_socket():


### PR DESCRIPTION
We see the following errors in cloud-init that this solves:

    tests/unittests/test_data.py:66: in setUp
        super(TestConsumeUserData, self).setUp()
    cloudinit/tests/helpers.py:245: in setUp
        super(FilesystemMockingTestCase, self).setUp()
    cloudinit/tests/helpers.py:230: in setUp
        super(ResourceUsingTestCase, self).setUp()
    cloudinit/tests/helpers.py:362: in setUp
        httpretty.enable()
    /usr/lib/python3.9/site-packages/httpretty/core.py:1818: in enable
        logger.setLevel(logging.getLogger().level)
    /usr/lib64/python3.9/logging/__init__.py:1421: in setLevel
        self.level = _checkLevel(level)
    _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ 
    level = None
        def _checkLevel(level):
            if isinstance(level, int):
                rv = level
            elif str(level) == level:
                if level not in _nameToLevel:
                    raise ValueError("Unknown level: %r" % level)
                rv = _nameToLevel[level]
            else:
    >           raise TypeError("Level not an integer or a valid string: %r" % level)
    E           TypeError: Level not an integer or a valid string: None
    /usr/lib64/python3.9/logging/__init__.py:201: TypeError