### PR TITLE
Fixes #425.

### DIFF
--- a/httpretty/core.py
+++ b/httpretty/core.py
@@ -796,7 +796,7 @@ class fakesock(object):
                     else:
                         self._entry.request.body += body
 
-                    httpretty.historify_request(headers, body, sock=self)
+                    httpretty.historify_request(headers, body, sock=self, append=False)
                     return
 
             if path[:2] == '//':
@@ -1602,7 +1602,7 @@ class httpretty(HttpBaseClass):
         __internals__.cleanup_sockets()
 
     @classmethod
-    def historify_request(cls, headers, body='', sock=None):
+    def historify_request(cls, headers, body='', sock=None, append=True):
         """appends request to a list for later retrieval
 
         .. testcode::
@@ -1618,7 +1618,7 @@ class httpretty(HttpBaseClass):
         request = HTTPrettyRequest(headers, body, sock=sock)
         cls.last_request = request
 
-        if request not in cls.latest_requests:
+        if append or not cls.latest_requests:
             cls.latest_requests.append(request)
         else:
             cls.latest_requests[-1] = request

--- a/tests/functional/test_requests.py
+++ b/tests/functional/test_requests.py
@@ -407,7 +407,7 @@ def test_multiline():
     expect(HTTPretty.last_request.body).to.equal(data)
     expect(HTTPretty.last_request.headers['content-length']).to.equal('37')
     expect(HTTPretty.last_request.headers['content-type']).to.equal('application/x-www-form-urlencoded; charset=utf-8')
-    expect(len(HTTPretty.latest_requests)).to.equal(2)
+    expect(len(HTTPretty.latest_requests)).to.equal(1)
 
 
 @httprettified
@@ -431,7 +431,7 @@ def test_octet_stream():
     expect(HTTPretty.last_request.body).to.equal(data)
     expect(HTTPretty.last_request.headers['content-length']).to.equal('4')
     expect(HTTPretty.last_request.headers['content-type']).to.equal('application/octet-stream')
-    expect(len(HTTPretty.latest_requests)).to.equal(2)
+    expect(len(HTTPretty.latest_requests)).to.equal(1)
 
 
 @httprettified
@@ -452,7 +452,7 @@ def test_multipart():
     expect(HTTPretty.last_request.body).to.equal(data)
     expect(HTTPretty.last_request.headers['content-length']).to.equal('495')
     expect(HTTPretty.last_request.headers['content-type']).to.equal('multipart/form-data; boundary=xXXxXXyYYzzz')
-    expect(len(HTTPretty.latest_requests)).to.equal(2)
+    expect(len(HTTPretty.latest_requests)).to.equal(1)
 
 
 @httprettified


### PR DESCRIPTION
This fixes a problem with duplicate entries in `latest_requests` on any POST request (not just chunked, any POST request results in duplicate entries in history).

I've done it by mostly restoring the code that was removed in b6161cebfdaf5f68ef49526e51b460b8e0c0c6c2

This PR doesn't add new tests because it also fixes broken tests that make a single POST request but expect two entries in `latest_requests`.