### PR TITLE
Switch to unittest.mock everywhere

### DIFF
--- a/development.txt
+++ b/development.txt
@@ -8,7 +8,6 @@ httplib2>=0.17.0
 httpx>=0.18.1
 ipdb>=0.13.2
 mccabe>=0.6.1
-mock>=3.0.5;python_version<"3.3"
 ndg-httpsclient>=0.5.1
 nose-randomly>=1.2.6
 nose>=1.3.7

--- a/tests/compat.py
+++ b/tests/compat.py
@@ -1,4 +1,0 @@
-try:
-    from unittest.mock import Mock, patch, call, MagicMock
-except ImportError:
-    from mock import Mock, patch, call, MagicMock

--- a/tests/functional/test_fakesocket.py
+++ b/tests/functional/test_fakesocket.py
@@ -28,7 +28,7 @@
 import functools
 import socket
 
-import mock
+from unittest.mock import patch
 
 
 class FakeSocket(socket.socket):
@@ -60,7 +60,7 @@ def recv(flag, size):
 recv = functools.partial(recv, fake_socket_interupter_flag)
 
 
-@mock.patch('httpretty.old_socket', new=FakeSocket)
+@patch('httpretty.old_socket', new=FakeSocket)
 def _test_shorten_response():
     u"HTTPretty shouldn't try to read from server when communication is over"
     from sure import expect
@@ -68,7 +68,7 @@ def _test_shorten_response():
 
     fakesocket = httpretty.fakesock.socket(socket.AF_INET,
                                            socket.SOCK_STREAM)
-    with mock.patch.object(fakesocket.truesock, 'recv', recv):
+    with patch.object(fakesocket.truesock, 'recv', recv):
         fakesocket.connect(('localhost', 80))
         fakesocket._true_sendall('WHATEVER')
         expect(fakesocket.fd.read()).to.equal(

--- a/tests/functional/test_requests.py
+++ b/tests/functional/test_requests.py
@@ -35,10 +35,10 @@ from sure import within, miliseconds, expect
 from tornado import version as tornado_version
 from httpretty import HTTPretty, httprettified
 from httpretty.core import decode_utf8
+from unittest.mock import Mock
 
 from tests.functional.base import FIXTURE_FILE, use_tornado_server
 
-from tests.compat import Mock
 
 
 try:

--- a/tests/unit/test_core.py
+++ b/tests/unit/test_core.py
@@ -1,14 +1,13 @@
 import io
 import json
 import errno
+from unittest.mock import Mock, patch, call
 
 from freezegun import freeze_time
 from sure import expect
 
 from httpretty.core import HTTPrettyRequest, FakeSSLSocket, fakesock, httpretty
 from httpretty.core import URIMatcher, URIInfo
-
-from tests.compat import Mock, patch, call
 
 
 class SocketErrorStub(Exception):

--- a/tests/unit/test_httpretty.py
+++ b/tests/unit/test_httpretty.py
@@ -28,14 +28,13 @@ from __future__ import unicode_literals
 import re
 import json
 from sure import expect
+from unittest.mock import MagicMock, patch
 import httpretty
 from httpretty import HTTPretty
 from httpretty import HTTPrettyError
 from httpretty import core
 from httpretty.core import URIInfo, BaseClass, Entry, FakeSockFile, HTTPrettyRequest
 from httpretty.http import STATUSES
-
-from tests.compat import MagicMock, patch
 
 
 TEST_HEADER = """


### PR DESCRIPTION
Since the lowest supported version of Python has included unittest.mock
for a long while, let's switch to it everywhere, and drop the now
unneeded tests.compat module.