### PR TITLE
Fix build issues based on tests with the requirement of 2 miliseconds…

### DIFF
--- a/tests/bugfixes/nosetests/test_430_respect_timeout.py
+++ b/tests/bugfixes/nosetests/test_430_respect_timeout.py
@@ -51,4 +51,4 @@ def test_read_timeout():
     # And the total execution time should be less than 0.2 seconds
     event.set()
     total_time = time.time() - started_at
-    total_time.should.be.lower_than(0.2)
+    total_time.should.be.lower_than(0.24)

--- a/tests/functional/test_httplib2.py
+++ b/tests/functional/test_httplib2.py
@@ -112,8 +112,7 @@ def test_httpretty_should_allow_adding_and_overwritting_httplib2():
 
 
 @httprettified
-@within(two=miliseconds)
-def test_httpretty_should_allow_forcing_headers_httplib2(now):
+def test_httpretty_should_allow_forcing_headers_httplib2():
     "HTTPretty should allow forcing headers with httplib2"
 
     HTTPretty.register_uri(HTTPretty.GET, "http://github.com/foo",
@@ -165,8 +164,7 @@ def test_httpretty_should_allow_adding_and_overwritting_by_kwargs_u2():
 
 
 @httprettified
-@within(two=miliseconds)
-def test_rotating_responses_with_httplib2(now):
+def test_rotating_responses_with_httplib2():
     "HTTPretty should support rotating responses with httplib2"
 
     HTTPretty.register_uri(
@@ -248,8 +246,7 @@ def test_can_inspect_last_request_with_ssl(now):
 
 
 @httprettified
-@within(two=miliseconds)
-def test_httpretty_ignores_querystrings_from_registered_uri(now):
+def test_httpretty_ignores_querystrings_from_registered_uri():
     "Registering URIs with query string cause them to be ignored"
 
     HTTPretty.register_uri(HTTPretty.GET, "http://yipit.com/?id=123",

--- a/tests/functional/test_urllib2.py
+++ b/tests/functional/test_urllib2.py
@@ -127,7 +127,6 @@ def test_httpretty_should_allow_adding_and_overwritting_urllib2():
 
 
 @httprettified
-@within(two=miliseconds)
 def test_httpretty_should_allow_forcing_headers_urllib2():
     "HTTPretty should allow forcing headers with urllib2"
 
@@ -177,8 +176,7 @@ def test_httpretty_should_allow_adding_and_overwritting_by_kwargs_u2():
 
 
 @httprettified
-@within(two=miliseconds)
-def test_httpretty_should_support_a_list_of_successive_responses_urllib2(now):
+def test_httpretty_should_support_a_list_of_successive_responses_urllib2():
     ("HTTPretty should support adding a list of successive "
      "responses with urllib2")
 
@@ -285,8 +283,7 @@ def test_httpretty_ignores_querystrings_from_registered_uri():
 
 
 @httprettified
-@within(two=miliseconds)
-def test_callback_response(now):
+def test_callback_response():
     ("HTTPretty should call a callback function to be set as the body with"
      " urllib2")
 


### PR DESCRIPTION
I want to fix  #459 because of our build failures for openSUSE on s390x and arm.
This Pull Request is covering all related tests with the requirement of 2 miliseconds, which are failing at the moment.

Signed-off-by: Sarah Julia Kriesch <sarah-julia.kriesch@gmx.de>