### PR TITLE
Fixed broken logo link

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -1,7 +1,7 @@
 HTTPretty 1.1.4
 ===============
 
-.. image:: https://github.com/gabrielfalcao/HTTPretty/raw/master/docs/source/_static/logo.svg?sanitize=true
+.. image:: https://github.com/gabrielfalcao/HTTPretty/blob/f9f012711597634d40066d144a36888b3addcc46/docs/source/_static/logo.svg
 
 HTTP Client mocking tool for Python created by `Gabriel Falcão <https://github.com/gabrielfalcao>`_ . It provides a full fake TCP socket module. Inspired by `FakeWeb <https://github.com/chrisk/fakeweb>`_
 


### PR DESCRIPTION
The logo link in the README was broken. I redirected it to the path: docs/source/_static/logo.svg.

<img width="915" alt="Screen Shot 2023-04-10 at 12 15 55 PM" src="https://user-images.githubusercontent.com/36302020/230943943-c0a49e43-6082-483a-ae3a-eb1098c37f7e.png">
