### PR TITLE
Separate headers by CR LF

### DIFF
--- a/httpretty/core.py
+++ b/httpretty/core.py
@@ -1130,7 +1130,7 @@ class Entry(BaseClass):
             )
 
         for item in string_list:
-            fk.write(utf8(item) + b'\n')
+            fk.write(utf8(item) + b'\r\n')
 
         fk.write(b'\r\n')
 


### PR DESCRIPTION
While using HTTPretty together with the last version of `aiohttp`, `aiohttp` failed to parse the response generated by `HTTPretty` due to the way headers are separated.
Specifically, `HTTPretty` separates them via the LF (`\n`) control code while `aiohttp` expects CR LF (`\r\n`).

This behavior (on `aiohttp`'s side) is also mentioned here https://github.com/aio-libs/aiohttp/issues/7494#issuecomment-1668546182 .

By searching a bit on the Internet (eg. [here](https://stackoverflow.com/a/5757349)) it seems that http parsers are expected to be lenient wrt parsing newlines, so I'm not sure this is technically a fault on `HTTPretty`'s side.

However I think it could be better to stay on the safe side and just use `\r\n` as separator for headers, which is the change I implemented with this PR.
