### PR TITLE
Fix test failing with chunked requests handled by urllib3

### DIFF
--- a/tests/functional/test_requests.py
+++ b/tests/functional/test_requests.py
@@ -678,7 +678,10 @@ def test_httpretty_should_allow_registering_regexes_with_streaming_responses():
     os.environ['DEBUG'] = 'true'
 
     def my_callback(request, url, headers):
-        request.body.should.equal(b'hithere')
+        if requests.__version__ < "2.29":
+            request.body.should.equal(b'hithere')
+        else:
+            request.body.should.equal(b'2\r\nhi\r\n5\r\nthere\r\n')
         return 200, headers, "Received"
 
     HTTPretty.register_uri(


### PR DESCRIPTION
I think [this change](https://requests.readthedocs.io/en/latest/community/updates/#id3) is making the test fail when using *python-requests-2.31.0-3.fc40* in the new fedora distro f40.
The breaking PR should be [this one](https://github.com/psf/requests/pull/6226).
I get this error:
```
#53 HTTPretty should allow registering regexes with streaming responses ... Exception in thread Thread-68 (fill_filekind):
Traceback (most recent call last):
  File "/usr/lib/python3.12/site-packages/sure/__init__.py", line 407, in wrapper
    value = func(self, *args, **kw)
            ^^^^^^^^^^^^^^^^^^^^^^^
  File "/usr/lib/python3.12/site-packages/sure/__init__.py", line 728, in equal
    raise error
  File "/usr/lib/python3.12/site-packages/sure/__init__.py", line 709, in equal
    comparison = DeepComparison(self.obj, what, epsilon).compare()
                 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/usr/lib/python3.12/site-packages/sure/core.py", line 251, in compare
    raise exp.as_assertion(original_X, original_Y)
          ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/usr/lib/python3.12/site-packages/sure/core.py", line 54, in as_assertion
    raise self.get_assertion(X, Y)
AssertionError: given
X = b'2\r\nhi\r\n5\r\nthere\r\n'
    and
Y = b'hithere'
X is b'2\r\nhi\r\n5\r\nthere\r\n' whereas Y is b'hithere'
During handling of the above exception, another exception occurred:
Traceback (most recent call last):
  File "/usr/lib64/python3.12/threading.py", line 1073, in _bootstrap_inner
    self.run()
  File "/usr/lib64/python3.12/threading.py", line 1010, in run
    self._target(*self._args, **self._kwargs)
  File "/builddir/build/BUILD/httpretty-1.1.4/httpretty/core.py", line 1097, in fill_filekind
    status, headers, self.body = self.callable_body(self.request, self.info.full_url(), headers)
                                 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/builddir/build/BUILD/httpretty-1.1.4/tests/functional/test_requests.py", line 681, in my_callback
    request.body.should.equal(b'hithere')
  File "/usr/lib/python3.12/site-packages/sure/__init__.py", line 409, in wrapper
    raise AssertionError(e)
AssertionError: given
X = b'2\r\nhi\r\n5\r\nthere\r\n'
    and
Y = b'hithere'
X is b'2\r\nhi\r\n5\r\nthere\r\n' whereas Y is b'hithere'
ERROR
======================================================================
ERROR: HTTPretty should allow registering regexes with streaming responses
----------------------------------------------------------------------
Traceback (most recent call last):
  File "/usr/lib/python3.12/site-packages/urllib3/connectionpool.py", line 715, in urlopen
    httplib_response = self._make_request(
                       ^^^^^^^^^^^^^^^^^^^
  File "/usr/lib/python3.12/site-packages/urllib3/connectionpool.py", line 467, in _make_request
    six.raise_from(e, None)
  File "<string>", line 3, in raise_from
  File "/usr/lib/python3.12/site-packages/urllib3/connectionpool.py", line 462, in _make_request
    httplib_response = conn.getresponse()
                       ^^^^^^^^^^^^^^^^^^
  File "/usr/lib64/python3.12/http/client.py", line 1419, in getresponse
    response.begin()
  File "/usr/lib64/python3.12/http/client.py", line 331, in begin
    version, status, reason = self._read_status()
                              ^^^^^^^^^^^^^^^^^^^
  File "/usr/lib64/python3.12/http/client.py", line 300, in _read_status
    raise RemoteDisconnected("Remote end closed connection without"
http.client.RemoteDisconnected: Remote end closed connection without response
During handling of the above exception, another exception occurred:
Traceback (most recent call last):
  File "/usr/lib/python3.12/site-packages/requests/adapters.py", line 486, in send
    resp = conn.urlopen(
           ^^^^^^^^^^^^^
  File "/usr/lib/python3.12/site-packages/urllib3/connectionpool.py", line 799, in urlopen
    retries = retries.increment(
              ^^^^^^^^^^^^^^^^^^
  File "/usr/lib/python3.12/site-packages/urllib3/util/retry.py", line 550, in increment
    raise six.reraise(type(error), error, _stacktrace)
          ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/usr/lib/python3.12/site-packages/urllib3/packages/six.py", line 769, in reraise
    raise value.with_traceback(tb)
  File "/usr/lib/python3.12/site-packages/urllib3/connectionpool.py", line 715, in urlopen
    httplib_response = self._make_request(
                       ^^^^^^^^^^^^^^^^^^^
  File "/usr/lib/python3.12/site-packages/urllib3/connectionpool.py", line 467, in _make_request
    six.raise_from(e, None)
  File "<string>", line 3, in raise_from
  File "/usr/lib/python3.12/site-packages/urllib3/connectionpool.py", line 462, in _make_request
    httplib_response = conn.getresponse()
                       ^^^^^^^^^^^^^^^^^^
  File "/usr/lib64/python3.12/http/client.py", line 1419, in getresponse
    response.begin()
  File "/usr/lib64/python3.12/http/client.py", line 331, in begin
    version, status, reason = self._read_status()
                              ^^^^^^^^^^^^^^^^^^^
  File "/usr/lib64/python3.12/http/client.py", line 300, in _read_status
    raise RemoteDisconnected("Remote end closed connection without"
urllib3.exceptions.ProtocolError: ('Connection aborted.', RemoteDisconnected('Remote end closed connection without response'))
During handling of the above exception, another exception occurred:
Traceback (most recent call last):
  File "/usr/lib/python3.12/site-packages/nose/case.py", line 201, in runTest
    self.test(*self.arg)
  File "/builddir/build/BUILD/httpretty-1.1.4/httpretty/core.py", line 2075, in wrapper
    return test(*args, **kw)
           ^^^^^^^^^^^^^^^^^
  File "/builddir/build/BUILD/httpretty-1.1.4/tests/functional/test_requests.py", line 694, in test_httpretty_should_allow_registering_regexes_with_streaming_responses
    response = requests.post(
               ^^^^^^^^^^^^^^
  File "/usr/lib/python3.12/site-packages/requests/api.py", line 115, in post
    return request("post", url, data=data, json=json, **kwargs)
           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/usr/lib/python3.12/site-packages/requests/api.py", line 59, in request
    return session.request(method=method, url=url, **kwargs)
           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/usr/lib/python3.12/site-packages/requests/sessions.py", line 589, in request
    resp = self.send(prep, **send_kwargs)
           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/usr/lib/python3.12/site-packages/requests/sessions.py", line 703, in send
    r = adapter.send(request, **kwargs)
        ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/usr/lib/python3.12/site-packages/requests/adapters.py", line 501, in send
    raise ConnectionError(err, request=request)
requests.exceptions.ConnectionError: ('Connection aborted.', RemoteDisconnected('Remote end closed connection without response'))
----------------------------------------------------------------------
```

