### PR TITLE
Fix test_417_openssl.py if pyOpenSSL not available

### DIFF
--- a/tests/bugfixes/nosetests/test_417_openssl.py
+++ b/tests/bugfixes/nosetests/test_417_openssl.py
@@ -24,6 +24,8 @@ def test_enable_disable_httpretty_extract():
     extract_from_urllib3()
     expect(urllib3.util.IS_PYOPENSSL).to.be.false
 
+@skipIf(extract_from_urllib3 is None,
+        "urllib3.contrib.pyopenssl.extract_from_urllib3 does not exist")
 def test_enable_disable_httpretty():
     "#417 urllib3.contrib.pyopenssl enable -> disable extract"
     expect(urllib3.util.IS_PYOPENSSL).to.be.false


### PR DESCRIPTION
Only one of the tests had the necessary @skipIf.