### PR TITLE
[ENG-000]  Patch shutdown method required in the latest urllib3 release

### DIFF
--- a/httpretty/core.py
+++ b/httpretty/core.py
@@ -872,6 +872,9 @@ class fakesock(object):
                 raise UnmockedError('socket cannot recv(): {!r}'.format(self))
 
             return self._read_buf.read(buffersize)
+        
+        def shutdown(self, *args, **kwargs):
+            return self.forward_and_trace('shutdown', *args, **kwargs)
 
         def __getattr__(self, name):
             if name in ('getsockopt', 'selected_alpn_protocol') and not self.truesock:

--- a/httpretty/core.py
+++ b/httpretty/core.py
@@ -949,7 +949,7 @@ def fake_gethostname():
 
 
 def fake_getaddrinfo(
-        host, port, family=None, socktype=None, proto=None, flags=None):
+        host, port, family=0, type=0, proto=0, flags=0):
     """drop-in replacement for :py:func:`socket.getaddrinfo`"""
     return [(socket.AF_INET, socket.SOCK_STREAM, socket.IPPROTO_TCP,
              '', (host, port)),

--- a/httpretty/version.py
+++ b/httpretty/version.py
@@ -1,1 +1,1 @@
-version = '1.1.4'
+version = '1.1.5a1'

--- a/httpretty/version.py
+++ b/httpretty/version.py
@@ -1,1 +1,1 @@
-version = '1.1.5a1'
+version = '1.1.6a1'


### PR DESCRIPTION
urllib3 2.3.0 added the HTTPResponse.shutdown(), which were not been mocked by httprety
https://github.com/urllib3/urllib3/releases/tag/2.3.0